### PR TITLE
Feature/documentation comment

### DIFF
--- a/src/Ast/Statement.elm
+++ b/src/Ast/Statement.elm
@@ -263,9 +263,13 @@ multiLineComment : Parser Statement
 multiLineComment =
   (Comment << String.fromList) <$> (string "{-" *> manyTill anyChar (string "-}"))
 
+documentationComment : Parser Statement
+documentationComment =
+  (Comment << String.fromList) <$> (string "{-|" *> manyTill anyChar (string "-}"))
+
 comment : Parser Statement
 comment =
-  singleLineComment <|> multiLineComment
+  singleLineComment <|> documentationComment <|> multiLineComment
 
 
 {-| A parser for stand-alone Elm statements. -}

--- a/tests/Statement.elm
+++ b/tests/Statement.elm
@@ -273,7 +273,6 @@ moduleFixityDeclarations =
          , InfixDeclaration R 1 "**"
          ]
 
-
 multiLineCommentInput : String
 multiLineCommentInput = """
 foo
@@ -281,7 +280,6 @@ bar
 
 baz
 """
-
 
 comments : Test
 comments =

--- a/tests/Statement.elm
+++ b/tests/Statement.elm
@@ -274,6 +274,30 @@ moduleFixityDeclarations =
          ]
 
 
+multiLineCommentInput : String
+multiLineCommentInput = """
+foo
+bar
+
+baz
+"""
+
+
+comments : Test
+comments =
+  describe "Comments"
+    [ test "single line" <|
+        \() -> "-- single line comment" `is` (Comment " single line comment")
+
+    , test "multi line comment with single line content" <|
+        \() -> "{- multi line comment -}" `is` (Comment " multi line comment ")
+
+    , test "multi line comment with multi line content" <|
+        \() -> ("{-" ++ multiLineCommentInput ++ "-}") `is` (Comment multiLineCommentInput)
+
+    , test "documentation comment" <|
+        \() -> ("{-|" ++ multiLineCommentInput ++ "-}") `is` (Comment multiLineCommentInput)
+    ]
 
 all : Test
 all =
@@ -286,4 +310,5 @@ all =
     , singleDeclaration
     , multipleDeclarations
     , moduleFixityDeclarations
+    , comments
     ]


### PR DESCRIPTION
This adds a separate parser for documentation comments. Though it probably does not make that much sense like that as one can not differentiate the different types of comments. The idea is to be able to support validations that exposed modules itself and their exposed types and values are properly documented.

Would you consider adding a separate comment type with tags for the different comments?
