### PR TITLE
update to elm 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "2.0.0",
     "summary": "A parser for Elm code",
     "repository": "https://github.com/Bogdanp/elm-ast.git",
     "license": "BSD3",
@@ -14,9 +14,9 @@
         "Ast.Statement"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "Bogdanp/elm-combine": "2.2.1 <= v < 3.0.0",
-        "elm-community/list-extra": "3.1.0 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "Bogdanp/elm-combine": "3.1.1 <= v < 4.0.0",
+        "elm-community/list-extra": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/example/Main.elm
+++ b/example/Main.elm
@@ -4,7 +4,7 @@ import Ast
 import Ast.Expression exposing (..)
 import Ast.Statement exposing (..)
 import Html exposing (..)
-import Html.App as App
+import Html
 import Html.Events exposing (..)
 import Json.Decode as JD
 
@@ -77,7 +77,7 @@ statement s =
 tree : String -> Html Msg
 tree m =
     case Ast.parse m of
-        ( Ok statements, _ ) ->
+        ( Ok (_, _, statements)) ->
             ul [] (List.map statement statements)
 
         err ->
@@ -92,9 +92,9 @@ view model =
         ]
 
 
-main : Program Never
+main : Program Never String Msg
 main =
-    App.beginnerProgram
+    Html.beginnerProgram
         { model = init
         , update = update
         , view = view

--- a/example/Main.elm
+++ b/example/Main.elm
@@ -45,12 +45,6 @@ withChild title children =
 expression : Expression -> Html Msg
 expression e =
     case e of
-        Range e1 e2 ->
-            withChild e
-                [ expression e1
-                , expression e2
-                ]
-
         List es ->
             withChild e (List.map expression es)
 

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -1,6 +1,6 @@
 {
-    "version": "1.0.0",
-    "summary": "an example",
+    "version": "2.0.0",
+    "summary": "example for elm-ast",
     "repository": "https://github.com/Bogdanp/elm-ast.git",
     "license": "BSD3",
     "source-directories": [
@@ -9,10 +9,10 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "Bogdanp/elm-combine": "2.1.0 <= v < 3.0.0",
-        "elm-community/list-extra": "3.1.0 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "Bogdanp/elm-combine": "3.1.0 <= v < 4.0.0",
+        "elm-community/list-extra": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Ast.elm
+++ b/src/Ast.elm
@@ -12,8 +12,7 @@ module Ast exposing
 
 -}
 
-import Combine exposing (Context, end)
-import Combine.Infix exposing ((<*))
+import Combine exposing (end, (<*))
 
 import Ast.BinOp exposing (OpTable, operators)
 import Ast.Expression exposing (Expression, expression)
@@ -21,31 +20,31 @@ import Ast.Statement exposing (Statement, statement, statements, opTable)
 
 
 {-| Parse an Elm expression. -}
-parseExpression : OpTable -> String -> (Result (List String) Expression, Context)
+parseExpression : OpTable -> String -> Result (Combine.ParseErr ()) (Combine.ParseOk () Expression)
 parseExpression ops = Combine.parse (expression ops <* end)
 
 
 {-| Parse an Elm statement. -}
-parseStatement : OpTable -> String -> (Result (List String) Statement, Context)
+parseStatement : OpTable -> String -> Result (Combine.ParseErr ()) (Combine.ParseOk () Statement)
 parseStatement ops = Combine.parse (statement ops <* end)
 
 
 {-| Parse an OpTable from a module. -}
-parseOpTable : OpTable -> String -> (Result (List String) OpTable, Context)
+parseOpTable : OpTable -> String -> Result (Combine.ParseErr ()) (Combine.ParseOk () OpTable)
 parseOpTable ops = Combine.parse (opTable ops)
 
 
 {-| Parse an Elm module. -}
-parseModule : OpTable -> String -> (Result (List String) (List Statement), Context)
+parseModule : OpTable -> String -> Result (Combine.ParseErr ()) (Combine.ParseOk () (List Statement))
 parseModule ops = Combine.parse (statements ops)
 
 
 {-| Parse an Elm module, scanning for infix declarations first. -}
-parse : String -> (Result (List String) (List Statement), Context)
+parse : String -> Result (Combine.ParseErr ()) (Combine.ParseOk () (List Statement))
 parse input =
   case parseOpTable operators input of
-    (Ok ops, _) ->
+    (Ok (state, stream, ops)) ->
       parseModule ops input
 
-    (Err ms, cx) ->
-      (Err ms, cx)
+    (Err e) ->
+      (Err e)

--- a/src/Ast/Expression.elm
+++ b/src/Ast/Expression.elm
@@ -33,7 +33,6 @@ type Expression
   | Integer Int
   | Float Float
   | Variable (List Name)
-  | Range Expression Expression
   | List (List Expression)
   | Access Expression (List Name)
   | Record (List (Name, Expression))
@@ -79,14 +78,6 @@ variable =
   Variable <$> choice [ singleton <$> loName
                       , sepBy1 (Combine.string "." ) upName
                       ]
-
-range : OpTable -> Parser s Expression
-range ops =
-  lazy <| \() ->
-    brackets
-      <| Range
-           <$> (expression ops)
-           <*> (symbol ".." *> expression ops)
 
 list : OpTable -> Parser s Expression
 list ops =
@@ -167,7 +158,7 @@ term : OpTable -> Parser s Expression
 term ops =
   lazy <| \() ->
     choice [ character, string, float, integer, access, variable
-           , range ops, list ops, record ops
+           , list ops, record ops
            , parens (expression ops)
            ]
 

--- a/src/Ast/Expression.elm
+++ b/src/Ast/Expression.elm
@@ -14,7 +14,6 @@ module Ast.Expression exposing
 
 import Combine exposing (..)
 import Combine.Char exposing (..)
-import Combine.Infix exposing (..)
 import Combine.Num
 import Dict exposing (Dict)
 import List.Extra exposing (break, singleton)
@@ -46,11 +45,11 @@ type Expression
   | Application Expression Expression
   | BinOp Expression Expression Expression
 
-character : Parser Expression
+character : Parser s Expression
 character =
-  Character <$> between' (char '\'') anyChar
+  Character <$> between_ (char '\'') anyChar
 
-string : Parser Expression
+string : Parser s Expression
 string =
   let
     singleString =
@@ -63,119 +62,119 @@ string =
   in
     multiString <|> singleString
 
-integer : Parser Expression
+integer : Parser s Expression
 integer =
   Integer <$> Combine.Num.int
 
-float : Parser Expression
+float : Parser s Expression
 float =
   Float <$> Combine.Num.float
 
-access : Parser Expression
+access : Parser s Expression
 access =
   Access <$> variable <*> many1 (Combine.string "." *> loName)
 
-variable : Parser Expression
+variable : Parser s Expression
 variable =
   Variable <$> choice [ singleton <$> loName
                       , sepBy1 (Combine.string "." ) upName
                       ]
 
-range : OpTable -> Parser Expression
+range : OpTable -> Parser s Expression
 range ops =
-  rec <| \() ->
+  lazy <| \() ->
     brackets
       <| Range
            <$> (expression ops)
            <*> (symbol ".." *> expression ops)
 
-list : OpTable -> Parser Expression
+list : OpTable -> Parser s Expression
 list ops =
-  rec <| \() ->
-    List <$> brackets (commaSeparated' (expression ops))
+  lazy <| \() ->
+    List <$> brackets (commaSeparated_ (expression ops))
 
-record : OpTable -> Parser Expression
+record : OpTable -> Parser s Expression
 record ops =
-  rec <| \() ->
-    Record <$> braces (commaSeparated' ((,) <$> loName <*> (symbol "=" *> expression ops)))
+  lazy <| \() ->
+    Record <$> braces (commaSeparated_ ((,) <$> loName <*> (symbol "=" *> expression ops)))
 
-letExpression : OpTable -> Parser Expression
+letExpression : OpTable -> Parser s Expression
 letExpression ops =
   let
     binding =
-      rec <| \() ->
+      lazy <| \() ->
         (,)
-          <$> (between' whitespace loName)
+          <$> (between_ whitespace loName)
           <*> (symbol "=" *> expression ops)
   in
-    rec <| \() ->
+    lazy <| \() ->
       Let
         <$> (symbol "let" *> many1 binding)
         <*> (symbol "in" *> expression ops)
 
-ifExpression : OpTable -> Parser Expression
+ifExpression : OpTable -> Parser s Expression
 ifExpression ops =
-  rec <| \() ->
+  lazy <| \() ->
     If
       <$> (symbol "if" *> expression ops)
       <*> (symbol "then" *> expression ops)
       <*> (symbol "else" *> expression ops)
 
-caseExpression : OpTable -> Parser Expression
+caseExpression : OpTable -> Parser s Expression
 caseExpression ops =
   let
     binding =
-      rec <| \() ->
+      lazy <| \() ->
         (,)
           <$> (whitespace *> expression ops)
           <*> (symbol "->" *> expression ops)
   in
-    rec <| \() ->
+    lazy <| \() ->
       Case
         <$> (symbol "case" *> expression ops)
         <*> (symbol "of" *> many1 binding)
 
-lambda : OpTable -> Parser Expression
+lambda : OpTable -> Parser s Expression
 lambda ops =
-  rec <| \() ->
+  lazy <| \() ->
     Lambda
-      <$> (symbol "\\" *> many (between' spaces loName))
+      <$> (symbol "\\" *> many (between_ spaces loName))
       <*> (symbol "->" *> expression ops)
 
-application : OpTable -> Parser Expression
+application : OpTable -> Parser s Expression
 application ops =
-  rec <| \() ->
-    term ops `chainl` (Application <$ spaces')
+  lazy <| \() ->
+    term ops |> chainl (Application <$ spaces_)
 
-binary : OpTable -> Parser Expression
+binary : OpTable -> Parser s Expression
 binary ops =
-  rec <| \() ->
+  lazy <| \() ->
     let
       next =
-        between' whitespace operator `andThen` \op ->
-          choice [ Cont <$> application ops, Stop <$> expression ops ] `andThen` \e ->
+        between_ whitespace operator |> andThen (\op ->
+          choice [ Cont <$> application ops, Stop <$> expression ops ] |> andThen (\e ->
             case e of
               Cont t -> ((::) (op, t)) <$> collect
-              Stop e -> succeed [(op, e)]
+              Stop e -> succeed [(op, e)]))
 
       collect = next <|> succeed []
     in
-      application ops `andThen` \e ->
-        collect `andThen` \eops ->
-          split ops 0 e eops
+      application ops |> andThen (\e ->
+        collect |> andThen (\eops ->
+          split ops 0 e eops))
 
-term : OpTable -> Parser Expression
+term : OpTable -> Parser s Expression
 term ops =
-  rec <| \() ->
+  lazy <| \() ->
     choice [ character, string, float, integer, access, variable
            , range ops, list ops, record ops
            , parens (expression ops)
            ]
 
 {-| A parser for Elm expressions. -}
-expression : OpTable -> Parser Expression
+expression : OpTable -> Parser s Expression
 expression ops =
-  rec <| \() ->
+  lazy <| \() ->
     choice [ letExpression ops
            , caseExpression ops
            , ifExpression ops
@@ -189,40 +188,40 @@ op ops n =
     |> Maybe.withDefault (L, 9)
 
 assoc : OpTable -> String -> Assoc
-assoc ops n = fst <| op ops n
+assoc ops n = Tuple.first <| op ops n
 
 level : OpTable -> String -> Int
-level ops n = snd <| op ops n
+level ops n = Tuple.second <| op ops n
 
 hasLevel : OpTable -> Int -> (String, Expression) -> Bool
 hasLevel ops l (n, _) = level ops n == l
 
-split : OpTable -> Int -> Expression -> List (String, Expression) -> Parser Expression
+split : OpTable -> Int -> Expression -> List (String, Expression) -> Parser s Expression
 split ops l e eops =
   case eops of
     [] ->
       succeed e
 
     _ ->
-      findAssoc ops l eops `andThen` \assoc ->
-        Ast.Helpers.sequence (splitLevel ops l e eops) `andThen` \es ->
-          let ops' = List.filterMap (\x -> if hasLevel ops l x
-                                           then Just (fst x)
-                                           else Nothing) eops in
-          case assoc of
-            R -> joinR es ops'
-            _ -> joinL es ops'
+      findAssoc ops l eops |> andThen (\assoc ->
+        sequence (splitLevel ops l e eops) |> andThen (\es ->
+          let ops_ = List.filterMap (\x -> if hasLevel ops l x
+                                           then Just (Tuple.first x)
+                                           else Nothing) eops
+          in case assoc of
+            R -> joinR es ops_
+            _ -> joinL es ops_))
 
-splitLevel : OpTable -> Int -> Expression -> List (String, Expression) -> List (Parser Expression)
+splitLevel : OpTable -> Int -> Expression -> List (String, Expression) -> List (Parser s Expression)
 splitLevel ops l e eops =
   case break (hasLevel ops l) eops of
-    (lops, (_, e')::rops) ->
-      split ops (l + 1) e lops :: splitLevel ops l e' rops
+    (lops, (_, e_)::rops) ->
+      split ops (l + 1) e lops :: splitLevel ops l e_ rops
 
     (lops, []) ->
       [ split ops (l + 1) e lops ]
 
-joinL : List Expression -> List String -> Parser Expression
+joinL : List Expression -> List String -> Parser s Expression
 joinL es ops =
   case (es, ops) of
     ([e], []) ->
@@ -232,28 +231,28 @@ joinL es ops =
       joinL ((BinOp (Variable [op]) a b) :: remE) remO
 
     _ ->
-      fail []
+      fail ""
 
-joinR : List Expression -> List String -> Parser Expression
+joinR : List Expression -> List String -> Parser s Expression
 joinR es ops =
   case (es, ops) of
     ([e], []) ->
       succeed e
 
     (a::b::remE, op::remO) ->
-      joinR (b::remE) remO `andThen` \e ->
-        succeed (BinOp (Variable [op]) a e)
+      joinR (b::remE) remO |> andThen (\e ->
+        succeed (BinOp (Variable [op]) a e))
 
     _ ->
-      fail []
+      fail ""
 
-findAssoc : OpTable -> Int -> List (String, Expression) -> Parser Assoc
+findAssoc : OpTable -> Int -> List (String, Expression) -> Parser s Assoc
 findAssoc ops l eops =
   let
     lops = List.filter (hasLevel ops l) eops
-    assocs = List.map (assoc ops << fst) lops
+    assocs = List.map (assoc ops << Tuple.first) lops
     error issue =
-      let operators = List.map fst lops |> String.join " and " in
+      let operators = List.map Tuple.first lops |> String.join " and " in
       "conflicting " ++ issue ++ " for operators " ++ operators
   in
     if List.all ((==) L) assocs then
@@ -263,6 +262,6 @@ findAssoc ops l eops =
     else if List.all ((==) N) assocs then
       case assocs of
         [_] -> succeed N
-        _   -> fail [ error "precedence" ]
+        _   -> fail <| error "precedence"
     else
-      fail [ error "associativity" ]
+      fail <| error "associativity"

--- a/src/Ast/Helpers.elm
+++ b/src/Ast/Helpers.elm
@@ -2,32 +2,12 @@ module Ast.Helpers exposing (..)
 
 import Combine exposing (..)
 import Combine.Char exposing (..)
-import Combine.Infix exposing (..)
 import String
 
 type alias Name = String
 type alias QualifiedType = List Name
 type alias ModuleName = List String
 type alias Alias = String
-
-sequence : List (Parser res) -> Parser (List res)
-sequence ps =
-  let
-    accumulate acc ps cx =
-      case ps of
-        [] ->
-          (Ok (List.reverse acc), cx)
-
-        p::ps ->
-          case app p cx of
-            (Ok res, rcx) ->
-              accumulate (res :: acc) ps rcx
-
-            (Err ms, ecx) ->
-              (Err ms, ecx)
-  in
-    primitive <| \cx ->
-      accumulate [] ps cx
 
 reserved : List Name
 reserved = [ "module", "where"
@@ -40,68 +20,65 @@ reserved = [ "module", "where"
 reservedOperators : List Name
 reservedOperators =  [ "=", ".", "..", "->", "--", "|", ":" ]
 
-between' : Parser a -> Parser res -> Parser res
-between' p = between p p
+between_ : Parser s a -> Parser s res -> Parser s res
+between_ p = between p p
 
-whitespace : Parser String
-whitespace = regex "[ \r\t\n]*"
-
-spaces : Parser String
+spaces : Parser s String
 spaces = regex "[ \t]*"
 
-spaces' : Parser String
-spaces' = regex "[ \t]+"
+spaces_ : Parser s String
+spaces_ = regex "[ \t]+"
 
-symbol : String -> Parser String
+symbol : String -> Parser s String
 symbol k =
-  between' whitespace (string k)
+  between_ whitespace (string k)
 
-initialSymbol : String -> Parser String
+initialSymbol : String -> Parser s String
 initialSymbol k =
   string k <* spaces
 
-commaSeparated : Parser res -> Parser (List res)
+commaSeparated : Parser s res -> Parser s (List res)
 commaSeparated p =
-  sepBy1 (string ",") (between' whitespace p)
+  sepBy1 (string ",") (between_ whitespace p)
 
-commaSeparated' : Parser res -> Parser (List res)
-commaSeparated' p =
-  sepBy (string ",") (between' whitespace p)
+commaSeparated_ : Parser s res -> Parser s (List res)
+commaSeparated_ p =
+  sepBy (string ",") (between_ whitespace p)
 
-name : Parser Char -> Parser String
+name : Parser s Char -> Parser s String
 name p =
   String.cons <$> p <*> regex "[a-zA-Z0-9-_']*"
 
-loName : Parser String
+loName : Parser s String
 loName =
   let
-    loName' =
-      name lower
-        `andThen` \n ->
+    loName_ =
+      name lower |>
+        andThen (\n ->
           if List.member n reserved
-          then fail [ "name '" ++ n ++ "' is reserved" ]
-          else succeed n
+          then fail <| "name '" ++ n ++ "' is reserved"
+          else succeed n)
   in
-    string "_" <|> loName'
+    string "_" <|> loName_
 
-upName : Parser String
+upName : Parser s String
 upName = name upper
 
-operator : Parser String
+operator : Parser s String
 operator =
-  between' (string "`") loName <|> symbolicOperator
+  between_ (string "`") loName <|> symbolicOperator
 
-symbolicOperator : Parser String
+symbolicOperator : Parser s String
 symbolicOperator =
-  regex "[+-/*=.$<>:&|^?%#@~!]+"
-    `andThen` \n ->
+  regex "[+-/*=.$<>:&|^?%#@~!]+" |>
+    andThen (\n ->
       if List.member n reservedOperators
-      then fail [ "operator '" ++ n ++ "' is reserved" ]
-      else succeed n
+      then fail <| "operator '" ++ n ++ "' is reserved"
+      else succeed n)
 
-functionName : Parser String
+functionName : Parser s String
 functionName = loName
 
-moduleName : Parser ModuleName
+moduleName : Parser s ModuleName
 moduleName =
-  between' spaces <| sepBy1 (string ".") upName
+  between_ spaces <| sepBy1 (string ".") upName

--- a/src/Ast/Helpers.elm
+++ b/src/Ast/Helpers.elm
@@ -47,7 +47,7 @@ commaSeparated_ p =
 
 name : Parser s Char -> Parser s String
 name p =
-  String.cons <$> p <*> regex "[a-zA-Z0-9-_']*"
+  String.cons <$> p <*> regex "[a-zA-Z0-9-_]*"
 
 loName : Parser s String
 loName =
@@ -66,10 +66,6 @@ upName = name upper
 
 operator : Parser s String
 operator =
-  between_ (string "`") loName <|> symbolicOperator
-
-symbolicOperator : Parser s String
-symbolicOperator =
   regex "[+-/*=.$<>:&|^?%#@~!]+" |>
     andThen (\n ->
       if List.member n reservedOperators

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -7,7 +7,7 @@ import Json.Encode exposing (Value)
 import Expression
 import Statement
 
-main : Program Value
+main : Test.Runner.Node.TestProgram
 main =
     run emit all
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,6 +1,6 @@
 {
-    "version": "1.0.0",
-    "summary": "helpful summary of your project, less than 80 characters",
+    "version": "2.0.0",
+    "summary": "test suite for elm-ast",
     "repository": "https://github.com/user/project.git",
     "license": "BSD3",
     "source-directories": [
@@ -9,11 +9,11 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.5 <= v < 5.0.0",
-        "elm-community/elm-test": "2.1.0 <= v < 3.0.0",
-        "rtfeldman/node-test-runner": "2.0.0 <= v < 3.0.0",
-        "Bogdanp/elm-combine": "2.1.0 <= v < 3.0.0",
-        "elm-community/list-extra": "3.1.0 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0",
+        "Bogdanp/elm-combine": "3.1.0 <= v < 4.0.0",
+        "elm-community/list-extra": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
fixes #14 
Hi,
- updated packages, updated package version to 2.0.0
- fixed compilation errors, updated parsers from `Parse res` to `Parse state res`
- updated parser to handle elm 0.18, see second commit. best language diff ever.
- might need cleanup, some parsers might be duplicated from elm-combine

Cheers