### PR TITLE
Closes #72 keywords in names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+dev:
+	cd example && make elm.js && open index.html

--- a/src/Ast/Expression.elm
+++ b/src/Ast/Expression.elm
@@ -194,7 +194,7 @@ letExpression ops =
     lazy <|
         \() ->
             Let
-                <$> (symbol "let" *> many1 (letBinding ops))
+                <$> (symbol_ "let" *> many1 (letBinding ops))
                 <*> (symbol "in" *> expression ops)
 
 
@@ -282,7 +282,7 @@ binary ops =
         \() ->
             let
                 next =
-                    between_ whitespace (choice [ operator, symbol "as" ])
+                    between_ whitespace (choice [ operator, symbol_ "as" ])
                         |> andThen
                             (\op ->
                                 choice [ Cont <$> application ops, Stop <$> expression ops ]

--- a/src/Ast/Helpers.elm
+++ b/src/Ast/Helpers.elm
@@ -53,12 +53,17 @@ between_ p =
 
 spaces : Parser s String
 spaces =
-    regex "[ \t]*"
+    regex "[ \\t]*"
 
 
 spaces_ : Parser s String
 spaces_ =
-    regex "[ \t]+"
+    regex "[ \\t]+"
+
+
+symbol_ : String -> Parser s String
+symbol_ k =
+    (between_ whitespace (string k <* regex " |\\n|\\r"))
 
 
 symbol : String -> Parser s String
@@ -68,7 +73,7 @@ symbol k =
 
 initialSymbol : String -> Parser s String
 initialSymbol k =
-    string k <* spaces
+    string k <* spaces_
 
 
 commaSeparated : Parser s res -> Parser s (List res)
@@ -114,7 +119,7 @@ emptyTuple =
 
 operator : Parser s String
 operator =
-    regex "[+\\-\\/*=.$<>:&|^?%#@~!]+|\x08as\x08"
+    regex "[+\\-\\/*=.$<>:&|^?%#@~!]+|\x8As\x08"
         |> andThen
             (\n ->
                 if List.member n reservedOperators then

--- a/tests/Expression.elm
+++ b/tests/Expression.elm
@@ -111,6 +111,14 @@ letExpressions =
                             [ ( var "_", Integer 42 ) ]
                             (Integer 24)
                         )
+        , test "Can start with a tag name" <|
+            \() ->
+                "let letter = 1 in letter"
+                    |> is
+                        (Let
+                            [ ( var "letter", Integer 1 ) ]
+                            (var "letter")
+                        )
         , test "function" <|
             \() ->
                 """


### PR DESCRIPTION
Should fix the issue. There might be some other occurrences but the fix is now known so they shouldn't be a problem if found