### PR TITLE
Add positional information

### DIFF
--- a/example/Main.elm
+++ b/example/Main.elm
@@ -53,7 +53,7 @@ expression e =
         List es _ ->
             withChild e (List.map expression es)
 
-        Application e1 e2 ->
+        Application e1 e2 m ->
             withChild e
                 [ expression e1
                 , expression e2

--- a/example/Main.elm
+++ b/example/Main.elm
@@ -34,10 +34,15 @@ update action model =
             m
 
 
+toText : a -> Html Msg
+toText =
+    text << toString
+
+
 withChild : a -> List (Html Msg) -> Html Msg
 withChild title children =
     li []
-        [ pre [] [ text <| toString title ]
+        [ pre [] [ toText title ]
         , ul [] children
         ]
 
@@ -45,7 +50,7 @@ withChild title children =
 expression : Expression -> Html Msg
 expression e =
     case e of
-        List es ->
+        List es _ ->
             withChild e (List.map expression es)
 
         Application e1 e2 ->
@@ -55,17 +60,17 @@ expression e =
                 ]
 
         e ->
-            li [] [ pre [] [ text <| toString e ] ]
+            li [] [ pre [] [ toText e ] ]
 
 
 statement : Statement -> Html Msg
 statement s =
     case s of
-        FunctionDeclaration _ _ e ->
+        FunctionDeclaration _ _ e _ ->
             withChild s [ expression e ]
 
         s ->
-            li [] [ pre [] [ text <| toString s ] ]
+            li [] [ pre [] [ toText s ] ]
 
 
 tree : String -> Html Msg
@@ -75,7 +80,7 @@ tree m =
             ul [] (List.map statement statements)
 
         err ->
-            div [] [ text <| toString err ]
+            div [] [ toText err ]
 
 
 view : String -> Html Msg

--- a/example/elm.js
+++ b/example/elm.js
@@ -5404,20 +5404,16 @@ var _Bogdanp$elm_ast$Ast_Helpers$reservedOperators = {
 		}
 	}
 };
-var _Bogdanp$elm_ast$Ast_Helpers$operator = _elm_community$parser_combinators$Combine$lazy(
-	function (_p0) {
-		var _p1 = _p0;
-		return A2(
-			_elm_community$parser_combinators$Combine_ops['>>='],
-			_elm_community$parser_combinators$Combine$regex('[+\\-\\/*=.$<>:&|^?%#@~!]+|s\b'),
-			function (n) {
-				return A2(_elm_lang$core$List$member, n, _Bogdanp$elm_ast$Ast_Helpers$reservedOperators) ? _elm_community$parser_combinators$Combine$fail(
-					A2(
-						_elm_lang$core$Basics_ops['++'],
-						'operator \'',
-						A2(_elm_lang$core$Basics_ops['++'], n, '\' is reserved'))) : _elm_community$parser_combinators$Combine$succeed(n);
-			});
-	});
+var _Bogdanp$elm_ast$Ast_Helpers$operator = A2(
+	_elm_community$parser_combinators$Combine$andThen,
+	function (n) {
+		return A2(_elm_lang$core$List$member, n, _Bogdanp$elm_ast$Ast_Helpers$reservedOperators) ? _elm_community$parser_combinators$Combine$fail(
+			A2(
+				_elm_lang$core$Basics_ops['++'],
+				'operator \'',
+				A2(_elm_lang$core$Basics_ops['++'], n, '\' is reserved'))) : _elm_community$parser_combinators$Combine$succeed(n);
+	},
+	_elm_community$parser_combinators$Combine$regex('[+\\-\\/*=.$<>:&|^?%#@~!]+|s\b'));
 var _Bogdanp$elm_ast$Ast_Helpers$reserved = {
 	ctor: '::',
 	_0: 'module',
@@ -5481,44 +5477,21 @@ var _Bogdanp$elm_ast$Ast_Helpers$reserved = {
 };
 var _Bogdanp$elm_ast$Ast_Helpers$loName = function () {
 	var loName_ = A2(
-		_elm_community$parser_combinators$Combine_ops['>>='],
-		_Bogdanp$elm_ast$Ast_Helpers$name(_elm_community$parser_combinators$Combine_Char$lower),
+		_elm_community$parser_combinators$Combine$andThen,
 		function (n) {
 			return A2(_elm_lang$core$List$member, n, _Bogdanp$elm_ast$Ast_Helpers$reserved) ? _elm_community$parser_combinators$Combine$fail(
 				A2(
 					_elm_lang$core$Basics_ops['++'],
 					'name \'',
 					A2(_elm_lang$core$Basics_ops['++'], n, '\' is reserved'))) : _elm_community$parser_combinators$Combine$succeed(n);
-		});
+		},
+		_Bogdanp$elm_ast$Ast_Helpers$name(_elm_community$parser_combinators$Combine_Char$lower));
 	return A2(
 		_elm_community$parser_combinators$Combine_ops['<|>'],
 		_elm_community$parser_combinators$Combine$string('_'),
 		loName_);
 }();
 var _Bogdanp$elm_ast$Ast_Helpers$functionName = _Bogdanp$elm_ast$Ast_Helpers$loName;
-var _Bogdanp$elm_ast$Ast_Helpers$makeMeta = function (_p2) {
-	var _p3 = _p2;
-	var _p4 = _p3.column;
-	return {
-		line: _p3.line,
-		column: (_elm_lang$core$Native_Utils.cmp(_p4, 0) < 0) ? 0 : _p4
-	};
-};
-var _Bogdanp$elm_ast$Ast_Helpers$withMeta = function (p) {
-	return _elm_community$parser_combinators$Combine$withLocation(
-		function (_p5) {
-			return A3(
-				_elm_lang$core$Basics$flip,
-				_elm_community$parser_combinators$Combine$andMap,
-				p,
-				_elm_community$parser_combinators$Combine$succeed(
-					_Bogdanp$elm_ast$Ast_Helpers$makeMeta(_p5)));
-		});
-};
-var _Bogdanp$elm_ast$Ast_Helpers$Meta = F2(
-	function (a, b) {
-		return {line: a, column: b};
-	});
 
 var _Bogdanp$elm_ast$Ast_BinOp$R = {ctor: 'R'};
 var _Bogdanp$elm_ast$Ast_BinOp$L = {ctor: 'L'};
@@ -5581,7 +5554,7 @@ var _Bogdanp$elm_ast$Ast_BinOp$operators = A3(
 														A3(
 															_elm_lang$core$Dict$insert,
 															'++',
-															{ctor: '_Tuple2', _0: _Bogdanp$elm_ast$Ast_BinOp$R, _1: 5},
+															{ctor: '_Tuple2', _0: _Bogdanp$elm_ast$Ast_BinOp$L, _1: 5},
 															A3(
 																_elm_lang$core$Dict$insert,
 																'<=',
@@ -7040,201 +7013,6 @@ var _elm_community$list_extra$List_Extra$init = function () {
 var _elm_community$list_extra$List_Extra$last = _elm_community$list_extra$List_Extra$foldl1(
 	_elm_lang$core$Basics$flip(_elm_lang$core$Basics$always));
 
-var _rtfeldman$hex$Hex$toString = function (num) {
-	return _elm_lang$core$String$fromList(
-		(_elm_lang$core$Native_Utils.cmp(num, 0) < 0) ? {
-			ctor: '::',
-			_0: _elm_lang$core$Native_Utils.chr('-'),
-			_1: A2(
-				_rtfeldman$hex$Hex$unsafePositiveToDigits,
-				{ctor: '[]'},
-				_elm_lang$core$Basics$negate(num))
-		} : A2(
-			_rtfeldman$hex$Hex$unsafePositiveToDigits,
-			{ctor: '[]'},
-			num));
-};
-var _rtfeldman$hex$Hex$unsafePositiveToDigits = F2(
-	function (digits, num) {
-		unsafePositiveToDigits:
-		while (true) {
-			if (_elm_lang$core$Native_Utils.cmp(num, 16) < 0) {
-				return {
-					ctor: '::',
-					_0: _rtfeldman$hex$Hex$unsafeToDigit(num),
-					_1: digits
-				};
-			} else {
-				var _v0 = {
-					ctor: '::',
-					_0: _rtfeldman$hex$Hex$unsafeToDigit(
-						A2(_elm_lang$core$Basics_ops['%'], num, 16)),
-					_1: digits
-				},
-					_v1 = (num / 16) | 0;
-				digits = _v0;
-				num = _v1;
-				continue unsafePositiveToDigits;
-			}
-		}
-	});
-var _rtfeldman$hex$Hex$unsafeToDigit = function (num) {
-	var _p0 = num;
-	switch (_p0) {
-		case 0:
-			return _elm_lang$core$Native_Utils.chr('0');
-		case 1:
-			return _elm_lang$core$Native_Utils.chr('1');
-		case 2:
-			return _elm_lang$core$Native_Utils.chr('2');
-		case 3:
-			return _elm_lang$core$Native_Utils.chr('3');
-		case 4:
-			return _elm_lang$core$Native_Utils.chr('4');
-		case 5:
-			return _elm_lang$core$Native_Utils.chr('5');
-		case 6:
-			return _elm_lang$core$Native_Utils.chr('6');
-		case 7:
-			return _elm_lang$core$Native_Utils.chr('7');
-		case 8:
-			return _elm_lang$core$Native_Utils.chr('8');
-		case 9:
-			return _elm_lang$core$Native_Utils.chr('9');
-		case 10:
-			return _elm_lang$core$Native_Utils.chr('a');
-		case 11:
-			return _elm_lang$core$Native_Utils.chr('b');
-		case 12:
-			return _elm_lang$core$Native_Utils.chr('c');
-		case 13:
-			return _elm_lang$core$Native_Utils.chr('d');
-		case 14:
-			return _elm_lang$core$Native_Utils.chr('e');
-		case 15:
-			return _elm_lang$core$Native_Utils.chr('f');
-		default:
-			return _elm_lang$core$Native_Utils.crashCase(
-				'Hex',
-				{
-					start: {line: 138, column: 5},
-					end: {line: 188, column: 84}
-				},
-				_p0)(
-				A2(
-					_elm_lang$core$Basics_ops['++'],
-					'Tried to convert ',
-					A2(
-						_elm_lang$core$Basics_ops['++'],
-						_rtfeldman$hex$Hex$toString(num),
-						' to hexadecimal.')));
-	}
-};
-var _rtfeldman$hex$Hex$fromStringHelp = F3(
-	function (position, chars, accumulated) {
-		var _p2 = chars;
-		if (_p2.ctor === '[]') {
-			return _elm_lang$core$Result$Ok(accumulated);
-		} else {
-			var recurse = function (additional) {
-				return A3(
-					_rtfeldman$hex$Hex$fromStringHelp,
-					position - 1,
-					_p2._1,
-					accumulated + (additional * Math.pow(16, position)));
-			};
-			var _p3 = _p2._0;
-			switch (_p3.valueOf()) {
-				case '0':
-					return recurse(0);
-				case '1':
-					return recurse(1);
-				case '2':
-					return recurse(2);
-				case '3':
-					return recurse(3);
-				case '4':
-					return recurse(4);
-				case '5':
-					return recurse(5);
-				case '6':
-					return recurse(6);
-				case '7':
-					return recurse(7);
-				case '8':
-					return recurse(8);
-				case '9':
-					return recurse(9);
-				case 'a':
-					return recurse(10);
-				case 'b':
-					return recurse(11);
-				case 'c':
-					return recurse(12);
-				case 'd':
-					return recurse(13);
-				case 'e':
-					return recurse(14);
-				case 'f':
-					return recurse(15);
-				default:
-					return _elm_lang$core$Result$Err(
-						A2(
-							_elm_lang$core$Basics_ops['++'],
-							_elm_lang$core$Basics$toString(_p3),
-							' is not a valid hexadecimal character.'));
-			}
-		}
-	});
-var _rtfeldman$hex$Hex$fromString = function (str) {
-	if (_elm_lang$core$String$isEmpty(str)) {
-		return _elm_lang$core$Result$Err('Empty strings are not valid hexadecimal strings.');
-	} else {
-		var formatError = function (err) {
-			return A2(
-				_elm_lang$core$String$join,
-				' ',
-				{
-					ctor: '::',
-					_0: _elm_lang$core$Basics$toString(str),
-					_1: {
-						ctor: '::',
-						_0: 'is not a valid hexadecimal string because',
-						_1: {
-							ctor: '::',
-							_0: err,
-							_1: {ctor: '[]'}
-						}
-					}
-				});
-		};
-		var result = function () {
-			if (A2(_elm_lang$core$String$startsWith, '-', str)) {
-				var list = A2(
-					_elm_lang$core$Maybe$withDefault,
-					{ctor: '[]'},
-					_elm_lang$core$List$tail(
-						_elm_lang$core$String$toList(str)));
-				return A2(
-					_elm_lang$core$Result$map,
-					_elm_lang$core$Basics$negate,
-					A3(
-						_rtfeldman$hex$Hex$fromStringHelp,
-						_elm_lang$core$List$length(list) - 1,
-						list,
-						0));
-			} else {
-				return A3(
-					_rtfeldman$hex$Hex$fromStringHelp,
-					_elm_lang$core$String$length(str) - 1,
-					_elm_lang$core$String$toList(str),
-					0);
-			}
-		}();
-		return A2(_elm_lang$core$Result$mapError, formatError, result);
-	}
-};
-
 var _Bogdanp$elm_ast$Ast_Expression$op = F2(
 	function (ops, n) {
 		return A2(
@@ -7326,25 +7104,6 @@ var _Bogdanp$elm_ast$Ast_Expression$findAssoc = F3(
 			}
 		}
 	});
-var _Bogdanp$elm_ast$Ast_Expression$operatorOrAsBetween = _elm_community$parser_combinators$Combine$lazy(
-	function (_p4) {
-		var _p5 = _p4;
-		return A2(
-			_Bogdanp$elm_ast$Ast_Helpers$between_,
-			_elm_community$parser_combinators$Combine$whitespace,
-			A2(
-				_elm_community$parser_combinators$Combine_ops['<|>'],
-				_Bogdanp$elm_ast$Ast_Helpers$operator,
-				_Bogdanp$elm_ast$Ast_Helpers$symbol_('as')));
-	});
-var _Bogdanp$elm_ast$Ast_Expression$negate = function (x) {
-	var _p6 = x;
-	if (_p6.ctor === 'Just') {
-		return _elm_community$parser_combinators$Combine$fail('');
-	} else {
-		return _elm_community$parser_combinators$Combine$succeed('');
-	}
-};
 var _Bogdanp$elm_ast$Ast_Expression$Stop = function (a) {
 	return {ctor: 'Stop', _0: a};
 };
@@ -7359,6 +7118,49 @@ var _Bogdanp$elm_ast$Ast_Expression$Application = F2(
 	function (a, b) {
 		return {ctor: 'Application', _0: a, _1: b};
 	});
+var _Bogdanp$elm_ast$Ast_Expression$Lambda = F2(
+	function (a, b) {
+		return {ctor: 'Lambda', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$Case = F2(
+	function (a, b) {
+		return {ctor: 'Case', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$Let = F2(
+	function (a, b) {
+		return {ctor: 'Let', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$If = F3(
+	function (a, b, c) {
+		return {ctor: 'If', _0: a, _1: b, _2: c};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$RecordUpdate = F2(
+	function (a, b) {
+		return {ctor: 'RecordUpdate', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$Record = function (a) {
+	return {ctor: 'Record', _0: a};
+};
+var _Bogdanp$elm_ast$Ast_Expression$AccessFunction = function (a) {
+	return {ctor: 'AccessFunction', _0: a};
+};
+var _Bogdanp$elm_ast$Ast_Expression$accessFunction = A2(
+	_elm_community$parser_combinators$Combine_ops['<$>'],
+	_Bogdanp$elm_ast$Ast_Expression$AccessFunction,
+	A2(
+		_elm_community$parser_combinators$Combine_ops['*>'],
+		_elm_community$parser_combinators$Combine$string('.'),
+		_Bogdanp$elm_ast$Ast_Helpers$loName));
+var _Bogdanp$elm_ast$Ast_Expression$Access = F2(
+	function (a, b) {
+		return {ctor: 'Access', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$Tuple = function (a) {
+	return {ctor: 'Tuple', _0: a};
+};
+var _Bogdanp$elm_ast$Ast_Expression$List = function (a) {
+	return {ctor: 'List', _0: a};
+};
 var _Bogdanp$elm_ast$Ast_Expression$Variable = function (a) {
 	return {ctor: 'Variable', _0: a};
 };
@@ -7368,75 +7170,107 @@ var _Bogdanp$elm_ast$Ast_Expression$variable = A2(
 	_elm_community$parser_combinators$Combine$choice(
 		{
 			ctor: '::',
-			_0: A2(_elm_community$parser_combinators$Combine_ops['<$>'], _elm_community$list_extra$List_Extra$singleton, _Bogdanp$elm_ast$Ast_Helpers$loName),
+			_0: A2(_elm_community$parser_combinators$Combine_ops['<$>'], _elm_community$list_extra$List_Extra$singleton, _Bogdanp$elm_ast$Ast_Helpers$emptyTuple),
 			_1: {
 				ctor: '::',
-				_0: A2(
-					_elm_community$parser_combinators$Combine$sepBy1,
-					_elm_community$parser_combinators$Combine$string('.'),
-					_Bogdanp$elm_ast$Ast_Helpers$upName),
+				_0: A2(_elm_community$parser_combinators$Combine_ops['<$>'], _elm_community$list_extra$List_Extra$singleton, _Bogdanp$elm_ast$Ast_Helpers$loName),
 				_1: {
 					ctor: '::',
 					_0: A2(
-						_elm_community$parser_combinators$Combine_ops['<$>'],
-						_elm_community$list_extra$List_Extra$singleton,
-						_elm_community$parser_combinators$Combine$parens(_Bogdanp$elm_ast$Ast_Helpers$operator)),
+						_elm_community$parser_combinators$Combine$sepBy1,
+						_elm_community$parser_combinators$Combine$string('.'),
+						_Bogdanp$elm_ast$Ast_Helpers$upName),
 					_1: {
 						ctor: '::',
 						_0: A2(
 							_elm_community$parser_combinators$Combine_ops['<$>'],
 							_elm_community$list_extra$List_Extra$singleton,
-							_elm_community$parser_combinators$Combine$parens(
-								_elm_community$parser_combinators$Combine$regex(',+'))),
+							_elm_community$parser_combinators$Combine$parens(_Bogdanp$elm_ast$Ast_Helpers$operator)),
 						_1: {
 							ctor: '::',
-							_0: A2(_elm_community$parser_combinators$Combine_ops['<$>'], _elm_community$list_extra$List_Extra$singleton, _Bogdanp$elm_ast$Ast_Helpers$emptyTuple),
+							_0: A2(
+								_elm_community$parser_combinators$Combine_ops['<$>'],
+								_elm_community$list_extra$List_Extra$singleton,
+								_elm_community$parser_combinators$Combine$parens(
+									_elm_community$parser_combinators$Combine$regex(',+'))),
 							_1: {ctor: '[]'}
 						}
 					}
 				}
 			}
 		}));
+var _Bogdanp$elm_ast$Ast_Expression$access = A2(
+	_elm_community$parser_combinators$Combine_ops['<*>'],
+	A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Access, _Bogdanp$elm_ast$Ast_Expression$variable),
+	_elm_community$parser_combinators$Combine$many1(
+		A2(
+			_elm_community$parser_combinators$Combine_ops['*>'],
+			_elm_community$parser_combinators$Combine$string('.'),
+			_Bogdanp$elm_ast$Ast_Helpers$loName)));
+var _Bogdanp$elm_ast$Ast_Expression$simplifiedRecord = _elm_community$parser_combinators$Combine$lazy(
+	function (_p4) {
+		var _p5 = _p4;
+		return A2(
+			_elm_community$parser_combinators$Combine_ops['<$>'],
+			_Bogdanp$elm_ast$Ast_Expression$Record,
+			_elm_community$parser_combinators$Combine$braces(
+				_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
+					A2(
+						_elm_community$parser_combinators$Combine_ops['<$>'],
+						function (a) {
+							return {
+								ctor: '_Tuple2',
+								_0: a,
+								_1: _Bogdanp$elm_ast$Ast_Expression$Variable(
+									{
+										ctor: '::',
+										_0: a,
+										_1: {ctor: '[]'}
+									})
+							};
+						},
+						_Bogdanp$elm_ast$Ast_Helpers$loName))));
+	});
 var _Bogdanp$elm_ast$Ast_Expression$joinL = F2(
 	function (es, ops) {
 		joinL:
 		while (true) {
-			var _p7 = {ctor: '_Tuple2', _0: es, _1: ops};
-			_v4_2:
+			var _p6 = {ctor: '_Tuple2', _0: es, _1: ops};
+			_v3_2:
 			do {
-				if ((_p7.ctor === '_Tuple2') && (_p7._0.ctor === '::')) {
-					if (_p7._0._1.ctor === '[]') {
-						if (_p7._1.ctor === '[]') {
-							return _elm_community$parser_combinators$Combine$succeed(_p7._0._0);
+				if ((_p6.ctor === '_Tuple2') && (_p6._0.ctor === '::')) {
+					if (_p6._0._1.ctor === '[]') {
+						if (_p6._1.ctor === '[]') {
+							return _elm_community$parser_combinators$Combine$succeed(_p6._0._0);
 						} else {
-							break _v4_2;
+							break _v3_2;
 						}
 					} else {
-						if (_p7._1.ctor === '::') {
-							var _v5 = {
+						if (_p6._1.ctor === '::') {
+							var _v4 = {
 								ctor: '::',
 								_0: A3(
 									_Bogdanp$elm_ast$Ast_Expression$BinOp,
 									_Bogdanp$elm_ast$Ast_Expression$Variable(
 										{
 											ctor: '::',
-											_0: _p7._1._0,
+											_0: _p6._1._0,
 											_1: {ctor: '[]'}
 										}),
-									_p7._0._0,
-									_p7._0._1._0),
-								_1: _p7._0._1._1
+									_p6._0._0,
+									_p6._0._1._0),
+								_1: _p6._0._1._1
 							},
-								_v6 = _p7._1._1;
-							es = _v5;
-							ops = _v6;
+								_v5 = _p6._1._1;
+							es = _v4;
+							ops = _v5;
 							continue joinL;
 						} else {
-							break _v4_2;
+							break _v3_2;
 						}
 					}
 				} else {
-					break _v4_2;
+					break _v3_2;
 				}
 			} while(false);
 			return _elm_community$parser_combinators$Combine$fail('');
@@ -7444,24 +7278,20 @@ var _Bogdanp$elm_ast$Ast_Expression$joinL = F2(
 	});
 var _Bogdanp$elm_ast$Ast_Expression$joinR = F2(
 	function (es, ops) {
-		var _p8 = {ctor: '_Tuple2', _0: es, _1: ops};
-		_v7_2:
+		var _p7 = {ctor: '_Tuple2', _0: es, _1: ops};
+		_v6_2:
 		do {
-			if ((_p8.ctor === '_Tuple2') && (_p8._0.ctor === '::')) {
-				if (_p8._0._1.ctor === '[]') {
-					if (_p8._1.ctor === '[]') {
-						return _elm_community$parser_combinators$Combine$succeed(_p8._0._0);
+			if ((_p7.ctor === '_Tuple2') && (_p7._0.ctor === '::')) {
+				if (_p7._0._1.ctor === '[]') {
+					if (_p7._1.ctor === '[]') {
+						return _elm_community$parser_combinators$Combine$succeed(_p7._0._0);
 					} else {
-						break _v7_2;
+						break _v6_2;
 					}
 				} else {
-					if (_p8._1.ctor === '::') {
+					if (_p7._1.ctor === '::') {
 						return A2(
-							_elm_community$parser_combinators$Combine_ops['>>='],
-							A2(
-								_Bogdanp$elm_ast$Ast_Expression$joinR,
-								{ctor: '::', _0: _p8._0._1._0, _1: _p8._0._1._1},
-								_p8._1._1),
+							_elm_community$parser_combinators$Combine$andThen,
 							function (e) {
 								return _elm_community$parser_combinators$Combine$succeed(
 									A3(
@@ -7469,36 +7299,37 @@ var _Bogdanp$elm_ast$Ast_Expression$joinR = F2(
 										_Bogdanp$elm_ast$Ast_Expression$Variable(
 											{
 												ctor: '::',
-												_0: _p8._1._0,
+												_0: _p7._1._0,
 												_1: {ctor: '[]'}
 											}),
-										_p8._0._0,
+										_p7._0._0,
 										e));
-							});
+							},
+							A2(
+								_Bogdanp$elm_ast$Ast_Expression$joinR,
+								{ctor: '::', _0: _p7._0._1._0, _1: _p7._0._1._1},
+								_p7._1._1));
 					} else {
-						break _v7_2;
+						break _v6_2;
 					}
 				}
 			} else {
-				break _v7_2;
+				break _v6_2;
 			}
 		} while(false);
 		return _elm_community$parser_combinators$Combine$fail('');
 	});
 var _Bogdanp$elm_ast$Ast_Expression$split = F4(
 	function (ops, l, e, eops) {
-		var _p9 = eops;
-		if (_p9.ctor === '[]') {
+		var _p8 = eops;
+		if (_p8.ctor === '[]') {
 			return _elm_community$parser_combinators$Combine$succeed(e);
 		} else {
 			return A2(
-				_elm_community$parser_combinators$Combine_ops['>>='],
-				A3(_Bogdanp$elm_ast$Ast_Expression$findAssoc, ops, l, eops),
+				_elm_community$parser_combinators$Combine$andThen,
 				function (assoc) {
 					return A2(
-						_elm_community$parser_combinators$Combine_ops['>>='],
-						_elm_community$parser_combinators$Combine$sequence(
-							A4(_Bogdanp$elm_ast$Ast_Expression$splitLevel, ops, l, e, eops)),
+						_elm_community$parser_combinators$Combine$andThen,
 						function (es) {
 							var ops_ = A2(
 								_elm_lang$core$List$filterMap,
@@ -7507,140 +7338,56 @@ var _Bogdanp$elm_ast$Ast_Expression$split = F4(
 										_elm_lang$core$Tuple$first(x)) : _elm_lang$core$Maybe$Nothing;
 								},
 								eops);
-							var _p10 = assoc;
-							if (_p10.ctor === 'R') {
+							var _p9 = assoc;
+							if (_p9.ctor === 'R') {
 								return A2(_Bogdanp$elm_ast$Ast_Expression$joinR, es, ops_);
 							} else {
 								return A2(_Bogdanp$elm_ast$Ast_Expression$joinL, es, ops_);
 							}
-						});
-				});
+						},
+						_elm_community$parser_combinators$Combine$sequence(
+							A4(_Bogdanp$elm_ast$Ast_Expression$splitLevel, ops, l, e, eops)));
+				},
+				A3(_Bogdanp$elm_ast$Ast_Expression$findAssoc, ops, l, eops));
 		}
 	});
 var _Bogdanp$elm_ast$Ast_Expression$splitLevel = F4(
 	function (ops, l, e, eops) {
-		var _p11 = A2(
+		var _p10 = A2(
 			_elm_community$list_extra$List_Extra$break,
 			A2(_Bogdanp$elm_ast$Ast_Expression$hasLevel, ops, l),
 			eops);
-		if (_p11._1.ctor === '::') {
+		if (_p10._1.ctor === '::') {
 			return {
 				ctor: '::',
-				_0: A4(_Bogdanp$elm_ast$Ast_Expression$split, ops, l + 1, e, _p11._0),
-				_1: A4(_Bogdanp$elm_ast$Ast_Expression$splitLevel, ops, l, _p11._1._0._1, _p11._1._1)
+				_0: A4(_Bogdanp$elm_ast$Ast_Expression$split, ops, l + 1, e, _p10._0),
+				_1: A4(_Bogdanp$elm_ast$Ast_Expression$splitLevel, ops, l, _p10._1._0._1, _p10._1._1)
 			};
 		} else {
 			return {
 				ctor: '::',
-				_0: A4(_Bogdanp$elm_ast$Ast_Expression$split, ops, l + 1, e, _p11._0),
+				_0: A4(_Bogdanp$elm_ast$Ast_Expression$split, ops, l + 1, e, _p10._0),
 				_1: {ctor: '[]'}
 			};
 		}
 	});
-var _Bogdanp$elm_ast$Ast_Expression$Lambda = F3(
-	function (a, b, c) {
-		return {ctor: 'Lambda', _0: a, _1: b, _2: c};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$Case = F3(
-	function (a, b, c) {
-		return {ctor: 'Case', _0: a, _1: b, _2: c};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$Let = F3(
-	function (a, b, c) {
-		return {ctor: 'Let', _0: a, _1: b, _2: c};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$If = F4(
-	function (a, b, c, d) {
-		return {ctor: 'If', _0: a, _1: b, _2: c, _3: d};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$RecordUpdate = F3(
-	function (a, b, c) {
-		return {ctor: 'RecordUpdate', _0: a, _1: b, _2: c};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$Record = F2(
-	function (a, b) {
-		return {ctor: 'Record', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$simplifiedRecord = _elm_community$parser_combinators$Combine$lazy(
-	function (_p12) {
-		var _p13 = _p12;
-		return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-			A2(
-				_elm_community$parser_combinators$Combine_ops['<$>'],
-				_Bogdanp$elm_ast$Ast_Expression$Record,
-				_elm_community$parser_combinators$Combine$braces(
-					_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
-						A2(
-							_elm_community$parser_combinators$Combine_ops['<$>'],
-							function (a) {
-								return {
-									ctor: '_Tuple2',
-									_0: a,
-									_1: _Bogdanp$elm_ast$Ast_Expression$Variable(
-										{
-											ctor: '::',
-											_0: a,
-											_1: {ctor: '[]'}
-										})
-								};
-							},
-							_Bogdanp$elm_ast$Ast_Helpers$loName)))));
-	});
-var _Bogdanp$elm_ast$Ast_Expression$AccessFunction = F2(
-	function (a, b) {
-		return {ctor: 'AccessFunction', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$accessFunction = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<$>'],
-		_Bogdanp$elm_ast$Ast_Expression$AccessFunction,
-		A2(
-			_elm_community$parser_combinators$Combine_ops['*>'],
-			_elm_community$parser_combinators$Combine$string('.'),
-			_Bogdanp$elm_ast$Ast_Helpers$loName)));
-var _Bogdanp$elm_ast$Ast_Expression$Access = F3(
-	function (a, b, c) {
-		return {ctor: 'Access', _0: a, _1: b, _2: c};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$access = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<*>'],
-		A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Access, _Bogdanp$elm_ast$Ast_Expression$variable),
-		_elm_community$parser_combinators$Combine$many1(
-			A2(
-				_elm_community$parser_combinators$Combine_ops['*>'],
-				_elm_community$parser_combinators$Combine$string('.'),
-				_Bogdanp$elm_ast$Ast_Helpers$loName))));
-var _Bogdanp$elm_ast$Ast_Expression$Tuple = F2(
-	function (a, b) {
-		return {ctor: 'Tuple', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$List = F2(
-	function (a, b) {
-		return {ctor: 'List', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$Float = F2(
-	function (a, b) {
-		return {ctor: 'Float', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$float = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-	A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Float, _elm_community$parser_combinators$Combine_Num$float));
-var _Bogdanp$elm_ast$Ast_Expression$Integer = F2(
-	function (a, b) {
-		return {ctor: 'Integer', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$integer = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-	A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Integer, _elm_community$parser_combinators$Combine_Num$int));
-var _Bogdanp$elm_ast$Ast_Expression$String = F2(
-	function (a, b) {
-		return {ctor: 'String', _0: a, _1: b};
-	});
+var _Bogdanp$elm_ast$Ast_Expression$Float = function (a) {
+	return {ctor: 'Float', _0: a};
+};
+var _Bogdanp$elm_ast$Ast_Expression$float = A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Float, _elm_community$parser_combinators$Combine_Num$float);
+var _Bogdanp$elm_ast$Ast_Expression$Integer = function (a) {
+	return {ctor: 'Integer', _0: a};
+};
+var _Bogdanp$elm_ast$Ast_Expression$integer = A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Integer, _elm_community$parser_combinators$Combine_Num$int);
+var _Bogdanp$elm_ast$Ast_Expression$String = function (a) {
+	return {ctor: 'String', _0: a};
+};
 var _Bogdanp$elm_ast$Ast_Expression$string = function () {
 	var multiString = A2(
 		_elm_community$parser_combinators$Combine_ops['<$>'],
-		function (_p14) {
+		function (_p11) {
 			return _Bogdanp$elm_ast$Ast_Expression$String(
-				_elm_lang$core$String$concat(_p14));
+				_elm_lang$core$String$concat(_p11));
 		},
 		A2(
 			_elm_community$parser_combinators$Combine_ops['<*'],
@@ -7660,147 +7407,100 @@ var _Bogdanp$elm_ast$Ast_Expression$string = function () {
 				_elm_community$parser_combinators$Combine$string('\"'),
 				_elm_community$parser_combinators$Combine$regex('(\\\\\\\\|\\\\\"|[^\"\n])*')),
 			_elm_community$parser_combinators$Combine$string('\"')));
-	return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-		A2(_elm_community$parser_combinators$Combine_ops['<|>'], multiString, singleString));
+	return A2(_elm_community$parser_combinators$Combine_ops['<|>'], multiString, singleString);
 }();
-var _Bogdanp$elm_ast$Ast_Expression$Character = F2(
-	function (a, b) {
-		return {ctor: 'Character', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$character = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+var _Bogdanp$elm_ast$Ast_Expression$Character = function (a) {
+	return {ctor: 'Character', _0: a};
+};
+var _Bogdanp$elm_ast$Ast_Expression$character = A2(
+	_elm_community$parser_combinators$Combine_ops['<$>'],
+	_Bogdanp$elm_ast$Ast_Expression$Character,
 	A2(
-		_elm_community$parser_combinators$Combine_ops['<$>'],
-		_Bogdanp$elm_ast$Ast_Expression$Character,
+		_Bogdanp$elm_ast$Ast_Helpers$between_,
+		_elm_community$parser_combinators$Combine$string('\''),
 		A2(
-			_Bogdanp$elm_ast$Ast_Helpers$between_,
-			_elm_community$parser_combinators$Combine$string('\''),
+			_elm_community$parser_combinators$Combine_ops['<|>'],
 			A2(
-				_elm_community$parser_combinators$Combine_ops['<|>'],
+				_elm_community$parser_combinators$Combine_ops['>>='],
 				A2(
-					_elm_community$parser_combinators$Combine_ops['>>='],
-					A2(
-						_elm_community$parser_combinators$Combine_ops['*>'],
-						_elm_community$parser_combinators$Combine$string('\\'),
-						_elm_community$parser_combinators$Combine$regex('(n|t|r|\\\\|x..)')),
-					function (a) {
-						var _p15 = _elm_lang$core$String$uncons(a);
-						_v12_6:
-						do {
-							if (_p15.ctor === 'Just') {
-								if (_p15._0.ctor === '_Tuple2') {
-									switch (_p15._0._0.valueOf()) {
-										case 'n':
-											if (_p15._0._1 === '') {
-												return _elm_community$parser_combinators$Combine$succeed(
-													_elm_lang$core$Native_Utils.chr('\n'));
-											} else {
-												break _v12_6;
-											}
-										case 't':
-											if (_p15._0._1 === '') {
-												return _elm_community$parser_combinators$Combine$succeed(
-													_elm_lang$core$Native_Utils.chr('\t'));
-											} else {
-												break _v12_6;
-											}
-										case 'r':
-											if (_p15._0._1 === '') {
-												return _elm_community$parser_combinators$Combine$succeed(
-													_elm_lang$core$Native_Utils.chr('\r'));
-											} else {
-												break _v12_6;
-											}
-										case '\\':
-											if (_p15._0._1 === '') {
-												return _elm_community$parser_combinators$Combine$succeed(
-													_elm_lang$core$Native_Utils.chr('\\'));
-											} else {
-												break _v12_6;
-											}
-										case '0':
-											if (_p15._0._1 === '') {
-												return _elm_community$parser_combinators$Combine$succeed(
-													_elm_lang$core$Native_Utils.chr(' '));
-											} else {
-												break _v12_6;
-											}
-										case 'x':
-											return A2(
-												_elm_lang$core$Result$withDefault,
-												_elm_community$parser_combinators$Combine$fail('Invalid charcode'),
-												A2(
-													_elm_lang$core$Result$map,
-													_elm_community$parser_combinators$Combine$succeed,
-													A2(
-														_elm_lang$core$Result$map,
-														_elm_lang$core$Char$fromCode,
-														_rtfeldman$hex$Hex$fromString(
-															_elm_lang$core$String$toLower(_p15._0._1)))));
-										default:
-											break _v12_6;
-									}
-								} else {
-									break _v12_6;
-								}
-							} else {
-								return _elm_community$parser_combinators$Combine$fail('No character');
-							}
-						} while(false);
-						return _elm_community$parser_combinators$Combine$fail(
-							A2(
-								_elm_lang$core$Basics_ops['++'],
-								'No such character as \\',
-								_elm_lang$core$Basics$toString(_p15._0)));
-					}),
-				_elm_community$parser_combinators$Combine_Char$anyChar))));
+					_elm_community$parser_combinators$Combine_ops['*>'],
+					_elm_community$parser_combinators$Combine$string('\\'),
+					_elm_community$parser_combinators$Combine$regex('(n|t|r|\\\\|x..)')),
+				function (a) {
+					var _p12 = a;
+					switch (_p12) {
+						case 'n':
+							return _elm_community$parser_combinators$Combine$succeed(
+								_elm_lang$core$Native_Utils.chr('\n'));
+						case 't':
+							return _elm_community$parser_combinators$Combine$succeed(
+								_elm_lang$core$Native_Utils.chr('\t'));
+						case 'r':
+							return _elm_community$parser_combinators$Combine$succeed(
+								_elm_lang$core$Native_Utils.chr('\r'));
+						case '\\':
+							return _elm_community$parser_combinators$Combine$succeed(
+								_elm_lang$core$Native_Utils.chr('\\'));
+						case '0':
+							return _elm_community$parser_combinators$Combine$succeed(
+								_elm_lang$core$Native_Utils.chr(' '));
+						case 'x00':
+							return _elm_community$parser_combinators$Combine$succeed(
+								_elm_lang$core$Native_Utils.chr(' '));
+						default:
+							return _elm_community$parser_combinators$Combine$fail(
+								A2(_elm_lang$core$Basics_ops['++'], 'No such character as \\', _p12));
+					}
+				}),
+			_elm_community$parser_combinators$Combine_Char$anyChar)));
 var _Bogdanp$elm_ast$Ast_Expression$term = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p16) {
-			var _p17 = _p16;
+		function (_p13) {
+			var _p14 = _p13;
 			return _elm_community$parser_combinators$Combine$choice(
 				{
 					ctor: '::',
-					_0: _Bogdanp$elm_ast$Ast_Expression$access,
+					_0: _Bogdanp$elm_ast$Ast_Expression$character,
 					_1: {
 						ctor: '::',
-						_0: _Bogdanp$elm_ast$Ast_Expression$variable,
+						_0: _Bogdanp$elm_ast$Ast_Expression$string,
 						_1: {
 							ctor: '::',
-							_0: _Bogdanp$elm_ast$Ast_Expression$accessFunction,
+							_0: _Bogdanp$elm_ast$Ast_Expression$float,
 							_1: {
 								ctor: '::',
-								_0: _Bogdanp$elm_ast$Ast_Expression$string,
+								_0: _Bogdanp$elm_ast$Ast_Expression$integer,
 								_1: {
 									ctor: '::',
-									_0: _Bogdanp$elm_ast$Ast_Expression$float,
+									_0: _Bogdanp$elm_ast$Ast_Expression$access,
 									_1: {
 										ctor: '::',
-										_0: _Bogdanp$elm_ast$Ast_Expression$integer,
+										_0: _Bogdanp$elm_ast$Ast_Expression$accessFunction,
 										_1: {
 											ctor: '::',
-											_0: _Bogdanp$elm_ast$Ast_Expression$character,
+											_0: _Bogdanp$elm_ast$Ast_Expression$variable,
 											_1: {
 												ctor: '::',
-												_0: _elm_community$parser_combinators$Combine$parens(
-													A2(
-														_Bogdanp$elm_ast$Ast_Helpers$between_,
-														_elm_community$parser_combinators$Combine$whitespace,
-														_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
+												_0: _Bogdanp$elm_ast$Ast_Expression$list(ops),
 												_1: {
 													ctor: '::',
-													_0: _Bogdanp$elm_ast$Ast_Expression$list(ops),
+													_0: _Bogdanp$elm_ast$Ast_Expression$tuple(ops),
 													_1: {
 														ctor: '::',
-														_0: _Bogdanp$elm_ast$Ast_Expression$tuple(ops),
+														_0: _Bogdanp$elm_ast$Ast_Expression$recordUpdate(ops),
 														_1: {
 															ctor: '::',
-															_0: _Bogdanp$elm_ast$Ast_Expression$recordUpdate(ops),
+															_0: _Bogdanp$elm_ast$Ast_Expression$record(ops),
 															_1: {
 																ctor: '::',
-																_0: _Bogdanp$elm_ast$Ast_Expression$record(ops),
+																_0: _Bogdanp$elm_ast$Ast_Expression$simplifiedRecord,
 																_1: {
 																	ctor: '::',
-																	_0: _Bogdanp$elm_ast$Ast_Expression$simplifiedRecord,
+																	_0: _elm_community$parser_combinators$Combine$parens(
+																		A2(
+																			_Bogdanp$elm_ast$Ast_Helpers$between_,
+																			_elm_community$parser_combinators$Combine$whitespace,
+																			_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
 																	_1: {ctor: '[]'}
 																}
 															}
@@ -7819,24 +7519,24 @@ var _Bogdanp$elm_ast$Ast_Expression$term = function (ops) {
 };
 var _Bogdanp$elm_ast$Ast_Expression$expression = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p18) {
-			var _p19 = _p18;
+		function (_p15) {
+			var _p16 = _p15;
 			return _elm_community$parser_combinators$Combine$choice(
 				{
 					ctor: '::',
-					_0: _Bogdanp$elm_ast$Ast_Expression$binary(ops),
+					_0: _Bogdanp$elm_ast$Ast_Expression$letExpression(ops),
 					_1: {
 						ctor: '::',
-						_0: _Bogdanp$elm_ast$Ast_Expression$letExpression(ops),
+						_0: _Bogdanp$elm_ast$Ast_Expression$caseExpression(ops),
 						_1: {
 							ctor: '::',
-							_0: _Bogdanp$elm_ast$Ast_Expression$caseExpression(ops),
+							_0: _Bogdanp$elm_ast$Ast_Expression$ifExpression(ops),
 							_1: {
 								ctor: '::',
-								_0: _Bogdanp$elm_ast$Ast_Expression$ifExpression(ops),
+								_0: _Bogdanp$elm_ast$Ast_Expression$lambda(ops),
 								_1: {
 									ctor: '::',
-									_0: _Bogdanp$elm_ast$Ast_Expression$lambda(ops),
+									_0: _Bogdanp$elm_ast$Ast_Expression$binary(ops),
 									_1: {ctor: '[]'}
 								}
 							}
@@ -7847,81 +7547,85 @@ var _Bogdanp$elm_ast$Ast_Expression$expression = function (ops) {
 };
 var _Bogdanp$elm_ast$Ast_Expression$binary = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p20) {
-			var _p21 = _p20;
+		function (_p17) {
+			var _p18 = _p17;
 			var next = A2(
-				_elm_community$parser_combinators$Combine_ops['>>='],
-				_Bogdanp$elm_ast$Ast_Expression$operatorOrAsBetween,
+				_elm_community$parser_combinators$Combine$andThen,
 				function (op) {
-					return _elm_community$parser_combinators$Combine$lazy(
-						function (_p22) {
-							var _p23 = _p22;
-							return A2(
-								_elm_community$parser_combinators$Combine_ops['>>='],
-								A2(
-									_elm_community$parser_combinators$Combine$or,
-									A2(
-										_elm_community$parser_combinators$Combine_ops['<$>'],
-										_Bogdanp$elm_ast$Ast_Expression$Cont,
-										_Bogdanp$elm_ast$Ast_Expression$application(ops)),
-									A2(
+					return A2(
+						_elm_community$parser_combinators$Combine$andThen,
+						function (e) {
+							var _p19 = e;
+							if (_p19.ctor === 'Cont') {
+								return A2(
+									_elm_community$parser_combinators$Combine_ops['<$>'],
+									F2(
+										function (x, y) {
+											return {ctor: '::', _0: x, _1: y};
+										})(
+										{ctor: '_Tuple2', _0: op, _1: _p19._0}),
+									collect);
+							} else {
+								return _elm_community$parser_combinators$Combine$succeed(
+									{
+										ctor: '::',
+										_0: {ctor: '_Tuple2', _0: op, _1: _p19._0},
+										_1: {ctor: '[]'}
+									});
+							}
+						},
+						_elm_community$parser_combinators$Combine$choice(
+							{
+								ctor: '::',
+								_0: A2(
+									_elm_community$parser_combinators$Combine_ops['<$>'],
+									_Bogdanp$elm_ast$Ast_Expression$Cont,
+									_Bogdanp$elm_ast$Ast_Expression$application(ops)),
+								_1: {
+									ctor: '::',
+									_0: A2(
 										_elm_community$parser_combinators$Combine_ops['<$>'],
 										_Bogdanp$elm_ast$Ast_Expression$Stop,
-										_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
-								function (e) {
-									var _p24 = e;
-									if (_p24.ctor === 'Cont') {
-										return A2(
-											_elm_community$parser_combinators$Combine_ops['<$>'],
-											F2(
-												function (x, y) {
-													return {ctor: '::', _0: x, _1: y};
-												})(
-												{ctor: '_Tuple2', _0: op, _1: _p24._0}),
-											collect);
-									} else {
-										return _elm_community$parser_combinators$Combine$succeed(
-											{
-												ctor: '::',
-												_0: {ctor: '_Tuple2', _0: op, _1: _p24._0},
-												_1: {ctor: '[]'}
-											});
-									}
-								});
-						});
-				});
-			var collect = _elm_community$parser_combinators$Combine$lazy(
-				function (_p25) {
-					var _p26 = _p25;
-					return _elm_community$parser_combinators$Combine$choice(
+										_Bogdanp$elm_ast$Ast_Expression$expression(ops)),
+									_1: {ctor: '[]'}
+								}
+							}));
+				},
+				A2(
+					_Bogdanp$elm_ast$Ast_Helpers$between_,
+					_elm_community$parser_combinators$Combine$whitespace,
+					_elm_community$parser_combinators$Combine$choice(
 						{
 							ctor: '::',
-							_0: next,
+							_0: _Bogdanp$elm_ast$Ast_Helpers$operator,
 							_1: {
 								ctor: '::',
-								_0: _elm_community$parser_combinators$Combine$succeed(
-									{ctor: '[]'}),
+								_0: _Bogdanp$elm_ast$Ast_Helpers$symbol_('as'),
 								_1: {ctor: '[]'}
 							}
-						});
-				});
+						})));
+			var collect = A2(
+				_elm_community$parser_combinators$Combine_ops['<|>'],
+				next,
+				_elm_community$parser_combinators$Combine$succeed(
+					{ctor: '[]'}));
 			return A2(
-				_elm_community$parser_combinators$Combine_ops['>>='],
-				_Bogdanp$elm_ast$Ast_Expression$application(ops),
+				_elm_community$parser_combinators$Combine$andThen,
 				function (e) {
 					return A2(
-						_elm_community$parser_combinators$Combine_ops['>>='],
-						collect,
+						_elm_community$parser_combinators$Combine$andThen,
 						function (eops) {
 							return A4(_Bogdanp$elm_ast$Ast_Expression$split, ops, 0, e, eops);
-						});
-				});
+						},
+						collect);
+				},
+				_Bogdanp$elm_ast$Ast_Expression$application(ops));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$application = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p27) {
-			var _p28 = _p27;
+		function (_p20) {
+			var _p21 = _p20;
 			return A2(
 				_elm_community$parser_combinators$Combine$chainl,
 				A2(
@@ -7932,45 +7636,36 @@ var _Bogdanp$elm_ast$Ast_Expression$application = function (ops) {
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$spacesOrIndentedNewline = function (ops) {
-	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p29) {
-			var _p30 = _p29;
-			return A2(
-				_elm_community$parser_combinators$Combine_ops['<|>'],
-				A2(
-					_elm_community$parser_combinators$Combine_ops['*>'],
-					_elm_community$parser_combinators$Combine$regex('[ \\t]*\n[ \\t]+'),
-					_Bogdanp$elm_ast$Ast_Expression$maybeBindingAhead(ops)),
-				_Bogdanp$elm_ast$Ast_Helpers$spaces_);
-		});
-};
-var _Bogdanp$elm_ast$Ast_Expression$maybeBindingAhead = function (ops) {
-	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p31) {
-			var _p32 = _p31;
-			return _elm_community$parser_combinators$Combine$lookAhead(
-				A2(
-					_elm_community$parser_combinators$Combine_ops['>>='],
-					function (_p33) {
-						return _elm_community$parser_combinators$Combine$maybe(
-							_elm_community$parser_combinators$Combine$choice(_p33));
-					}(
-						{
-							ctor: '::',
-							_0: _Bogdanp$elm_ast$Ast_Expression$letBinding(ops),
-							_1: {
-								ctor: '::',
-								_0: _Bogdanp$elm_ast$Ast_Expression$caseBinding(ops),
-								_1: {ctor: '[]'}
-							}
-						}),
-					_Bogdanp$elm_ast$Ast_Expression$negate));
-		});
+	var startsBinding = A2(
+		_elm_community$parser_combinators$Combine$or,
+		_Bogdanp$elm_ast$Ast_Expression$letBinding(ops),
+		_Bogdanp$elm_ast$Ast_Expression$caseBinding(ops));
+	var failAtBinding = A2(
+		_elm_community$parser_combinators$Combine$andThen,
+		function (x) {
+			var _p22 = x;
+			if (_p22.ctor === 'Just') {
+				return _elm_community$parser_combinators$Combine$fail('next line starts a new case or let binding');
+			} else {
+				return _elm_community$parser_combinators$Combine$succeed('');
+			}
+		},
+		_elm_community$parser_combinators$Combine$maybe(startsBinding));
+	return A2(
+		_elm_community$parser_combinators$Combine$or,
+		A2(
+			_elm_community$parser_combinators$Combine_ops['*>'],
+			A2(
+				_elm_community$parser_combinators$Combine_ops['*>'],
+				A2(_elm_community$parser_combinators$Combine_ops['*>'], _Bogdanp$elm_ast$Ast_Helpers$spaces, _elm_community$parser_combinators$Combine_Char$newline),
+				_Bogdanp$elm_ast$Ast_Helpers$spaces_),
+			_elm_community$parser_combinators$Combine$lookAhead(failAtBinding)),
+		_Bogdanp$elm_ast$Ast_Helpers$spaces_);
 };
 var _Bogdanp$elm_ast$Ast_Expression$caseBinding = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p34) {
-			var _p35 = _p34;
+		function (_p23) {
+			var _p24 = _p23;
 			return A2(
 				_elm_community$parser_combinators$Combine_ops['<*>'],
 				A2(
@@ -7991,8 +7686,8 @@ var _Bogdanp$elm_ast$Ast_Expression$caseBinding = function (ops) {
 };
 var _Bogdanp$elm_ast$Ast_Expression$letBinding = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p36) {
-			var _p37 = _p36;
+		function (_p25) {
+			var _p26 = _p25;
 			return A2(
 				_elm_community$parser_combinators$Combine_ops['<*>'],
 				A2(
@@ -8013,118 +7708,146 @@ var _Bogdanp$elm_ast$Ast_Expression$letBinding = function (ops) {
 };
 var _Bogdanp$elm_ast$Ast_Expression$caseExpression = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p38) {
-			var _p39 = _p38;
-			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+		function (_p27) {
+			var _p28 = _p27;
+			return A2(
+				_elm_community$parser_combinators$Combine_ops['<*>'],
 				A2(
-					_elm_community$parser_combinators$Combine_ops['<*>'],
-					A2(
-						_elm_community$parser_combinators$Combine_ops['<$>'],
-						_Bogdanp$elm_ast$Ast_Expression$Case,
-						A2(
-							_elm_community$parser_combinators$Combine_ops['*>'],
-							_Bogdanp$elm_ast$Ast_Helpers$symbol('case'),
-							_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
+					_elm_community$parser_combinators$Combine_ops['<$>'],
+					_Bogdanp$elm_ast$Ast_Expression$Case,
 					A2(
 						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$symbol('of'),
-						_elm_community$parser_combinators$Combine$many1(
-							_Bogdanp$elm_ast$Ast_Expression$caseBinding(ops)))));
+						_Bogdanp$elm_ast$Ast_Helpers$symbol('case'),
+						_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
+				A2(
+					_elm_community$parser_combinators$Combine_ops['*>'],
+					_Bogdanp$elm_ast$Ast_Helpers$symbol('of'),
+					_elm_community$parser_combinators$Combine$many1(
+						_Bogdanp$elm_ast$Ast_Expression$caseBinding(ops))));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$ifExpression = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p40) {
-			var _p41 = _p40;
-			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+		function (_p29) {
+			var _p30 = _p29;
+			return A2(
+				_elm_community$parser_combinators$Combine_ops['<*>'],
 				A2(
 					_elm_community$parser_combinators$Combine_ops['<*>'],
 					A2(
-						_elm_community$parser_combinators$Combine_ops['<*>'],
-						A2(
-							_elm_community$parser_combinators$Combine_ops['<$>'],
-							_Bogdanp$elm_ast$Ast_Expression$If,
-							A2(
-								_elm_community$parser_combinators$Combine_ops['*>'],
-								_Bogdanp$elm_ast$Ast_Helpers$symbol('if'),
-								_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
+						_elm_community$parser_combinators$Combine_ops['<$>'],
+						_Bogdanp$elm_ast$Ast_Expression$If,
 						A2(
 							_elm_community$parser_combinators$Combine_ops['*>'],
-							_Bogdanp$elm_ast$Ast_Helpers$symbol('then'),
+							_Bogdanp$elm_ast$Ast_Helpers$symbol('if'),
 							_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
 					A2(
 						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$symbol('else'),
-						_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
+						_Bogdanp$elm_ast$Ast_Helpers$symbol('then'),
+						_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
+				A2(
+					_elm_community$parser_combinators$Combine_ops['*>'],
+					_Bogdanp$elm_ast$Ast_Helpers$symbol('else'),
+					_Bogdanp$elm_ast$Ast_Expression$expression(ops)));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$lambda = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p42) {
-			var _p43 = _p42;
-			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+		function (_p31) {
+			var _p32 = _p31;
+			return A2(
+				_elm_community$parser_combinators$Combine_ops['<*>'],
 				A2(
-					_elm_community$parser_combinators$Combine_ops['<*>'],
-					A2(
-						_elm_community$parser_combinators$Combine_ops['<$>'],
-						_Bogdanp$elm_ast$Ast_Expression$Lambda,
-						A2(
-							_elm_community$parser_combinators$Combine_ops['*>'],
-							_Bogdanp$elm_ast$Ast_Helpers$symbol('\\'),
-							_elm_community$parser_combinators$Combine$many(
-								A2(
-									_Bogdanp$elm_ast$Ast_Helpers$between_,
-									_Bogdanp$elm_ast$Ast_Helpers$spaces,
-									_Bogdanp$elm_ast$Ast_Expression$term(ops))))),
+					_elm_community$parser_combinators$Combine_ops['<$>'],
+					_Bogdanp$elm_ast$Ast_Expression$Lambda,
 					A2(
 						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$symbol('->'),
-						_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
+						_Bogdanp$elm_ast$Ast_Helpers$symbol('\\'),
+						_elm_community$parser_combinators$Combine$many(
+							A2(
+								_Bogdanp$elm_ast$Ast_Helpers$between_,
+								_Bogdanp$elm_ast$Ast_Helpers$spaces,
+								_Bogdanp$elm_ast$Ast_Expression$term(ops))))),
+				A2(
+					_elm_community$parser_combinators$Combine_ops['*>'],
+					_Bogdanp$elm_ast$Ast_Helpers$symbol('->'),
+					_Bogdanp$elm_ast$Ast_Expression$expression(ops)));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$letExpression = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p44) {
-			var _p45 = _p44;
-			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+		function (_p33) {
+			var _p34 = _p33;
+			return A2(
+				_elm_community$parser_combinators$Combine_ops['<*>'],
 				A2(
-					_elm_community$parser_combinators$Combine_ops['<*>'],
-					A2(
-						_elm_community$parser_combinators$Combine_ops['<$>'],
-						_Bogdanp$elm_ast$Ast_Expression$Let,
-						A2(
-							_elm_community$parser_combinators$Combine_ops['*>'],
-							_Bogdanp$elm_ast$Ast_Helpers$symbol_('let'),
-							_elm_community$parser_combinators$Combine$many1(
-								_Bogdanp$elm_ast$Ast_Expression$letBinding(ops)))),
+					_elm_community$parser_combinators$Combine_ops['<$>'],
+					_Bogdanp$elm_ast$Ast_Expression$Let,
 					A2(
 						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$symbol('in'),
-						_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
+						_Bogdanp$elm_ast$Ast_Helpers$symbol_('let'),
+						_elm_community$parser_combinators$Combine$many1(
+							_Bogdanp$elm_ast$Ast_Expression$letBinding(ops)))),
+				A2(
+					_elm_community$parser_combinators$Combine_ops['*>'],
+					_Bogdanp$elm_ast$Ast_Helpers$symbol('in'),
+					_Bogdanp$elm_ast$Ast_Expression$expression(ops)));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$list = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p46) {
-			var _p47 = _p46;
-			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-				A2(
-					_elm_community$parser_combinators$Combine_ops['<$>'],
-					_Bogdanp$elm_ast$Ast_Expression$List,
-					_elm_community$parser_combinators$Combine$brackets(
-						_Bogdanp$elm_ast$Ast_Helpers$commaSeparated_(
-							_Bogdanp$elm_ast$Ast_Expression$expression(ops)))));
+		function (_p35) {
+			var _p36 = _p35;
+			return A2(
+				_elm_community$parser_combinators$Combine_ops['<$>'],
+				_Bogdanp$elm_ast$Ast_Expression$List,
+				_elm_community$parser_combinators$Combine$brackets(
+					_Bogdanp$elm_ast$Ast_Helpers$commaSeparated_(
+						_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$record = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p48) {
-			var _p49 = _p48;
-			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+		function (_p37) {
+			var _p38 = _p37;
+			return A2(
+				_elm_community$parser_combinators$Combine_ops['<$>'],
+				_Bogdanp$elm_ast$Ast_Expression$Record,
+				_elm_community$parser_combinators$Combine$braces(
+					_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
+						A2(
+							_elm_community$parser_combinators$Combine_ops['<*>'],
+							A2(
+								_elm_community$parser_combinators$Combine_ops['<$>'],
+								F2(
+									function (v0, v1) {
+										return {ctor: '_Tuple2', _0: v0, _1: v1};
+									}),
+								_Bogdanp$elm_ast$Ast_Helpers$loName),
+							A2(
+								_elm_community$parser_combinators$Combine_ops['*>'],
+								_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
+								_Bogdanp$elm_ast$Ast_Expression$expression(ops))))));
+		});
+};
+var _Bogdanp$elm_ast$Ast_Expression$recordUpdate = function (ops) {
+	return _elm_community$parser_combinators$Combine$lazy(
+		function (_p39) {
+			var _p40 = _p39;
+			return A2(
+				_elm_community$parser_combinators$Combine_ops['<*>'],
 				A2(
 					_elm_community$parser_combinators$Combine_ops['<$>'],
-					_Bogdanp$elm_ast$Ast_Expression$Record,
-					_elm_community$parser_combinators$Combine$braces(
+					_Bogdanp$elm_ast$Ast_Expression$RecordUpdate,
+					A2(
+						_elm_community$parser_combinators$Combine_ops['*>'],
+						_Bogdanp$elm_ast$Ast_Helpers$symbol('{'),
+						_Bogdanp$elm_ast$Ast_Helpers$loName)),
+				A2(
+					_elm_community$parser_combinators$Combine_ops['<*'],
+					A2(
+						_elm_community$parser_combinators$Combine_ops['*>'],
+						_Bogdanp$elm_ast$Ast_Helpers$symbol('|'),
 						_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
 							A2(
 								_elm_community$parser_combinators$Combine_ops['<*>'],
@@ -8138,66 +7861,30 @@ var _Bogdanp$elm_ast$Ast_Expression$record = function (ops) {
 								A2(
 									_elm_community$parser_combinators$Combine_ops['*>'],
 									_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
-									_Bogdanp$elm_ast$Ast_Expression$expression(ops)))))));
-		});
-};
-var _Bogdanp$elm_ast$Ast_Expression$recordUpdate = function (ops) {
-	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p50) {
-			var _p51 = _p50;
-			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-				A2(
-					_elm_community$parser_combinators$Combine_ops['<*>'],
-					A2(
-						_elm_community$parser_combinators$Combine_ops['<$>'],
-						_Bogdanp$elm_ast$Ast_Expression$RecordUpdate,
-						A2(
-							_elm_community$parser_combinators$Combine_ops['*>'],
-							_Bogdanp$elm_ast$Ast_Helpers$symbol('{'),
-							_Bogdanp$elm_ast$Ast_Helpers$loName)),
-					A2(
-						_elm_community$parser_combinators$Combine_ops['<*'],
-						A2(
-							_elm_community$parser_combinators$Combine_ops['*>'],
-							_Bogdanp$elm_ast$Ast_Helpers$symbol('|'),
-							_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
-								A2(
-									_elm_community$parser_combinators$Combine_ops['<*>'],
-									A2(
-										_elm_community$parser_combinators$Combine_ops['<$>'],
-										F2(
-											function (v0, v1) {
-												return {ctor: '_Tuple2', _0: v0, _1: v1};
-											}),
-										_Bogdanp$elm_ast$Ast_Helpers$loName),
-									A2(
-										_elm_community$parser_combinators$Combine_ops['*>'],
-										_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
-										_Bogdanp$elm_ast$Ast_Expression$expression(ops))))),
-						_Bogdanp$elm_ast$Ast_Helpers$symbol('}'))));
+									_Bogdanp$elm_ast$Ast_Expression$expression(ops))))),
+					_Bogdanp$elm_ast$Ast_Helpers$symbol('}')));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$tuple = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p52) {
-			var _p53 = _p52;
-			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+		function (_p41) {
+			var _p42 = _p41;
+			return A2(
+				_elm_community$parser_combinators$Combine_ops['<$>'],
+				_Bogdanp$elm_ast$Ast_Expression$Tuple,
 				A2(
-					_elm_community$parser_combinators$Combine_ops['<$>'],
-					_Bogdanp$elm_ast$Ast_Expression$Tuple,
-					A2(
-						_elm_community$parser_combinators$Combine_ops['>>='],
-						_elm_community$parser_combinators$Combine$parens(
-							_Bogdanp$elm_ast$Ast_Helpers$commaSeparated_(
-								_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
-						function (a) {
-							var _p54 = a;
-							if ((_p54.ctor === '::') && (_p54._1.ctor === '[]')) {
-								return _elm_community$parser_combinators$Combine$fail('No single tuples');
-							} else {
-								return _elm_community$parser_combinators$Combine$succeed(_p54);
-							}
-						})));
+					_elm_community$parser_combinators$Combine_ops['>>='],
+					_elm_community$parser_combinators$Combine$parens(
+						_Bogdanp$elm_ast$Ast_Helpers$commaSeparated_(
+							_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
+					function (a) {
+						var _p43 = a;
+						if ((_p43.ctor === '::') && (_p43._1.ctor === '[]')) {
+							return _elm_community$parser_combinators$Combine$fail('No single tuples');
+						} else {
+							return _elm_community$parser_combinators$Combine$succeed(_p43);
+						}
+					}));
 		});
 };
 
@@ -8452,76 +8139,72 @@ var _Bogdanp$elm_ast$Ast_Statement$typeTuple = _elm_community$parser_combinators
 			_elm_community$parser_combinators$Combine$parens(
 				_Bogdanp$elm_ast$Ast_Helpers$commaSeparated_(_Bogdanp$elm_ast$Ast_Statement$type_)));
 	});
-var _Bogdanp$elm_ast$Ast_Statement$Comment = F2(
-	function (a, b) {
-		return {ctor: 'Comment', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$singleLineComment = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+var _Bogdanp$elm_ast$Ast_Statement$Comment = function (a) {
+	return {ctor: 'Comment', _0: a};
+};
+var _Bogdanp$elm_ast$Ast_Statement$singleLineComment = A2(
+	_elm_community$parser_combinators$Combine_ops['<$>'],
+	_Bogdanp$elm_ast$Ast_Statement$Comment,
 	A2(
-		_elm_community$parser_combinators$Combine_ops['<$>'],
-		_Bogdanp$elm_ast$Ast_Statement$Comment,
-		A2(
-			_elm_community$parser_combinators$Combine_ops['<*'],
-			A2(
-				_elm_community$parser_combinators$Combine_ops['*>'],
-				_elm_community$parser_combinators$Combine$string('--'),
-				_elm_community$parser_combinators$Combine$regex('.*')),
-			_elm_community$parser_combinators$Combine$whitespace)));
-var _Bogdanp$elm_ast$Ast_Statement$multiLineComment = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<$>'],
-		function (_p18) {
-			return _Bogdanp$elm_ast$Ast_Statement$Comment(
-				_elm_lang$core$String$fromList(_p18));
-		},
+		_elm_community$parser_combinators$Combine_ops['<*'],
 		A2(
 			_elm_community$parser_combinators$Combine_ops['*>'],
-			_elm_community$parser_combinators$Combine$string('{-'),
-			A2(
-				_elm_community$parser_combinators$Combine$manyTill,
-				_elm_community$parser_combinators$Combine_Char$anyChar,
-				_elm_community$parser_combinators$Combine$string('-}')))));
+			_elm_community$parser_combinators$Combine$string('--'),
+			_elm_community$parser_combinators$Combine$regex('.*')),
+		_elm_community$parser_combinators$Combine$whitespace));
+var _Bogdanp$elm_ast$Ast_Statement$multiLineComment = A2(
+	_elm_community$parser_combinators$Combine_ops['<$>'],
+	function (_p18) {
+		return _Bogdanp$elm_ast$Ast_Statement$Comment(
+			_elm_lang$core$String$fromList(_p18));
+	},
+	A2(
+		_elm_community$parser_combinators$Combine_ops['*>'],
+		_elm_community$parser_combinators$Combine$string('{-'),
+		A2(
+			_elm_community$parser_combinators$Combine$manyTill,
+			_elm_community$parser_combinators$Combine_Char$anyChar,
+			_elm_community$parser_combinators$Combine$string('-}'))));
 var _Bogdanp$elm_ast$Ast_Statement$comment = A2(_elm_community$parser_combinators$Combine_ops['<|>'], _Bogdanp$elm_ast$Ast_Statement$singleLineComment, _Bogdanp$elm_ast$Ast_Statement$multiLineComment);
-var _Bogdanp$elm_ast$Ast_Statement$InfixDeclaration = F4(
-	function (a, b, c, d) {
-		return {ctor: 'InfixDeclaration', _0: a, _1: b, _2: c, _3: d};
+var _Bogdanp$elm_ast$Ast_Statement$InfixDeclaration = F3(
+	function (a, b, c) {
+		return {ctor: 'InfixDeclaration', _0: a, _1: b, _2: c};
 	});
-var _Bogdanp$elm_ast$Ast_Statement$infixDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+var _Bogdanp$elm_ast$Ast_Statement$infixDeclaration = A2(
+	_elm_community$parser_combinators$Combine_ops['<*>'],
 	A2(
 		_elm_community$parser_combinators$Combine_ops['<*>'],
 		A2(
-			_elm_community$parser_combinators$Combine_ops['<*>'],
-			A2(
-				_elm_community$parser_combinators$Combine_ops['<$>'],
-				_Bogdanp$elm_ast$Ast_Statement$InfixDeclaration,
-				_elm_community$parser_combinators$Combine$choice(
-					{
+			_elm_community$parser_combinators$Combine_ops['<$>'],
+			_Bogdanp$elm_ast$Ast_Statement$InfixDeclaration,
+			_elm_community$parser_combinators$Combine$choice(
+				{
+					ctor: '::',
+					_0: A2(
+						_elm_community$parser_combinators$Combine_ops['<$'],
+						_Bogdanp$elm_ast$Ast_BinOp$L,
+						_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infixl')),
+					_1: {
 						ctor: '::',
 						_0: A2(
 							_elm_community$parser_combinators$Combine_ops['<$'],
-							_Bogdanp$elm_ast$Ast_BinOp$L,
-							_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infixl')),
+							_Bogdanp$elm_ast$Ast_BinOp$R,
+							_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infixr')),
 						_1: {
 							ctor: '::',
 							_0: A2(
 								_elm_community$parser_combinators$Combine_ops['<$'],
-								_Bogdanp$elm_ast$Ast_BinOp$R,
-								_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infixr')),
-							_1: {
-								ctor: '::',
-								_0: A2(
-									_elm_community$parser_combinators$Combine_ops['<$'],
-									_Bogdanp$elm_ast$Ast_BinOp$N,
-									_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infix')),
-								_1: {ctor: '[]'}
-							}
+								_Bogdanp$elm_ast$Ast_BinOp$N,
+								_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infix')),
+							_1: {ctor: '[]'}
 						}
-					})),
-			A2(_elm_community$parser_combinators$Combine_ops['*>'], _Bogdanp$elm_ast$Ast_Helpers$spaces, _elm_community$parser_combinators$Combine_Num$int)),
-		A2(
-			_elm_community$parser_combinators$Combine_ops['*>'],
-			_Bogdanp$elm_ast$Ast_Helpers$spaces,
-			A2(_elm_community$parser_combinators$Combine_ops['<|>'], _Bogdanp$elm_ast$Ast_Helpers$loName, _Bogdanp$elm_ast$Ast_Helpers$operator))));
+					}
+				})),
+		A2(_elm_community$parser_combinators$Combine_ops['*>'], _Bogdanp$elm_ast$Ast_Helpers$spaces, _elm_community$parser_combinators$Combine_Num$int)),
+	A2(
+		_elm_community$parser_combinators$Combine_ops['*>'],
+		_Bogdanp$elm_ast$Ast_Helpers$spaces,
+		A2(_elm_community$parser_combinators$Combine_ops['<|>'], _Bogdanp$elm_ast$Ast_Helpers$loName, _Bogdanp$elm_ast$Ast_Helpers$operator)));
 var _Bogdanp$elm_ast$Ast_Statement$infixStatements = function () {
 	var statements = A2(
 		_elm_community$parser_combinators$Combine_ops['<*'],
@@ -8544,12 +8227,12 @@ var _Bogdanp$elm_ast$Ast_Statement$infixStatements = function () {
 				_elm_community$parser_combinators$Combine$whitespace)),
 		_elm_community$parser_combinators$Combine$end);
 	return A2(
-		_elm_community$parser_combinators$Combine_ops['>>='],
-		statements,
+		_elm_community$parser_combinators$Combine$andThen,
 		function (xs) {
 			return _elm_community$parser_combinators$Combine$succeed(
 				A2(_elm_lang$core$List$filterMap, _elm_lang$core$Basics$identity, xs));
-		});
+		},
+		statements);
 }();
 var _Bogdanp$elm_ast$Ast_Statement$opTable = function (ops) {
 	var collect = F2(
@@ -8565,68 +8248,32 @@ var _Bogdanp$elm_ast$Ast_Statement$opTable = function (ops) {
 				return _elm_lang$core$Native_Utils.crashCase(
 					'Ast.Statement',
 					{
-						start: {line: 427, column: 13},
-						end: {line: 432, column: 45}
+						start: {line: 414, column: 13},
+						end: {line: 419, column: 45}
 					},
 					_p19)('impossible');
 			}
 		});
 	return A2(
-		_elm_community$parser_combinators$Combine_ops['>>='],
-		_Bogdanp$elm_ast$Ast_Statement$infixStatements,
+		_elm_community$parser_combinators$Combine$andThen,
 		function (xs) {
 			return _elm_community$parser_combinators$Combine$succeed(
 				A3(_elm_lang$core$List$foldr, collect, ops, xs));
-		});
+		},
+		_Bogdanp$elm_ast$Ast_Statement$infixStatements);
 };
-var _Bogdanp$elm_ast$Ast_Statement$FunctionDeclaration = F4(
-	function (a, b, c, d) {
-		return {ctor: 'FunctionDeclaration', _0: a, _1: b, _2: c, _3: d};
+var _Bogdanp$elm_ast$Ast_Statement$FunctionDeclaration = F3(
+	function (a, b, c) {
+		return {ctor: 'FunctionDeclaration', _0: a, _1: b, _2: c};
 	});
 var _Bogdanp$elm_ast$Ast_Statement$functionDeclaration = function (ops) {
-	return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	return A2(
+		_elm_community$parser_combinators$Combine_ops['<*>'],
 		A2(
 			_elm_community$parser_combinators$Combine_ops['<*>'],
 			A2(
-				_elm_community$parser_combinators$Combine_ops['<*>'],
-				A2(
-					_elm_community$parser_combinators$Combine_ops['<$>'],
-					_Bogdanp$elm_ast$Ast_Statement$FunctionDeclaration,
-					_elm_community$parser_combinators$Combine$choice(
-						{
-							ctor: '::',
-							_0: _Bogdanp$elm_ast$Ast_Helpers$loName,
-							_1: {
-								ctor: '::',
-								_0: _elm_community$parser_combinators$Combine$parens(_Bogdanp$elm_ast$Ast_Helpers$operator),
-								_1: {ctor: '[]'}
-							}
-						})),
-				_elm_community$parser_combinators$Combine$many(
-					A2(
-						_Bogdanp$elm_ast$Ast_Helpers$between_,
-						_elm_community$parser_combinators$Combine$whitespace,
-						_Bogdanp$elm_ast$Ast_Expression$term(ops)))),
-			A2(
-				_elm_community$parser_combinators$Combine_ops['*>'],
-				A2(
-					_elm_community$parser_combinators$Combine_ops['*>'],
-					_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
-					_elm_community$parser_combinators$Combine$whitespace),
-				_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
-};
-var _Bogdanp$elm_ast$Ast_Statement$FunctionTypeDeclaration = F3(
-	function (a, b, c) {
-		return {ctor: 'FunctionTypeDeclaration', _0: a, _1: b, _2: c};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$functionTypeDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<*>'],
-		A2(
-			_elm_community$parser_combinators$Combine_ops['<$>'],
-			_Bogdanp$elm_ast$Ast_Statement$FunctionTypeDeclaration,
-			A2(
-				_elm_community$parser_combinators$Combine_ops['<*'],
+				_elm_community$parser_combinators$Combine_ops['<$>'],
+				_Bogdanp$elm_ast$Ast_Statement$FunctionDeclaration,
 				_elm_community$parser_combinators$Combine$choice(
 					{
 						ctor: '::',
@@ -8636,249 +8283,270 @@ var _Bogdanp$elm_ast$Ast_Statement$functionTypeDeclaration = _Bogdanp$elm_ast$As
 							_0: _elm_community$parser_combinators$Combine$parens(_Bogdanp$elm_ast$Ast_Helpers$operator),
 							_1: {ctor: '[]'}
 						}
-					}),
-				_Bogdanp$elm_ast$Ast_Helpers$symbol(':'))),
-		_Bogdanp$elm_ast$Ast_Statement$typeAnnotation));
-var _Bogdanp$elm_ast$Ast_Statement$PortDeclaration = F4(
-	function (a, b, c, d) {
-		return {ctor: 'PortDeclaration', _0: a, _1: b, _2: c, _3: d};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$portDeclaration = function (ops) {
-	return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-		A2(
-			_elm_community$parser_combinators$Combine_ops['<*>'],
-			A2(
-				_elm_community$parser_combinators$Combine_ops['<*>'],
+					})),
+			_elm_community$parser_combinators$Combine$many(
 				A2(
-					_elm_community$parser_combinators$Combine_ops['<$>'],
-					_Bogdanp$elm_ast$Ast_Statement$PortDeclaration,
-					A2(
-						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
-						_Bogdanp$elm_ast$Ast_Helpers$loName)),
-				_elm_community$parser_combinators$Combine$many(
-					A2(_Bogdanp$elm_ast$Ast_Helpers$between_, _Bogdanp$elm_ast$Ast_Helpers$spaces, _Bogdanp$elm_ast$Ast_Helpers$loName))),
+					_Bogdanp$elm_ast$Ast_Helpers$between_,
+					_elm_community$parser_combinators$Combine$whitespace,
+					_Bogdanp$elm_ast$Ast_Expression$term(ops)))),
+		A2(
+			_elm_community$parser_combinators$Combine_ops['*>'],
 			A2(
 				_elm_community$parser_combinators$Combine_ops['*>'],
 				_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
-				_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
+				_elm_community$parser_combinators$Combine$whitespace),
+			_Bogdanp$elm_ast$Ast_Expression$expression(ops)));
 };
-var _Bogdanp$elm_ast$Ast_Statement$PortTypeDeclaration = F3(
-	function (a, b, c) {
-		return {ctor: 'PortTypeDeclaration', _0: a, _1: b, _2: c};
+var _Bogdanp$elm_ast$Ast_Statement$FunctionTypeDeclaration = F2(
+	function (a, b) {
+		return {ctor: 'FunctionTypeDeclaration', _0: a, _1: b};
 	});
-var _Bogdanp$elm_ast$Ast_Statement$portTypeDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+var _Bogdanp$elm_ast$Ast_Statement$functionTypeDeclaration = A2(
+	_elm_community$parser_combinators$Combine_ops['<*>'],
 	A2(
+		_elm_community$parser_combinators$Combine_ops['<$>'],
+		_Bogdanp$elm_ast$Ast_Statement$FunctionTypeDeclaration,
+		A2(
+			_elm_community$parser_combinators$Combine_ops['<*'],
+			_elm_community$parser_combinators$Combine$choice(
+				{
+					ctor: '::',
+					_0: _Bogdanp$elm_ast$Ast_Helpers$loName,
+					_1: {
+						ctor: '::',
+						_0: _elm_community$parser_combinators$Combine$parens(_Bogdanp$elm_ast$Ast_Helpers$operator),
+						_1: {ctor: '[]'}
+					}
+				}),
+			_Bogdanp$elm_ast$Ast_Helpers$symbol(':'))),
+	_Bogdanp$elm_ast$Ast_Statement$typeAnnotation);
+var _Bogdanp$elm_ast$Ast_Statement$PortDeclaration = F3(
+	function (a, b, c) {
+		return {ctor: 'PortDeclaration', _0: a, _1: b, _2: c};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$portDeclaration = function (ops) {
+	return A2(
 		_elm_community$parser_combinators$Combine_ops['<*>'],
 		A2(
-			_elm_community$parser_combinators$Combine_ops['<$>'],
-			_Bogdanp$elm_ast$Ast_Statement$PortTypeDeclaration,
+			_elm_community$parser_combinators$Combine_ops['<*>'],
 			A2(
-				_elm_community$parser_combinators$Combine_ops['*>'],
-				_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
-				_Bogdanp$elm_ast$Ast_Helpers$loName)),
+				_elm_community$parser_combinators$Combine_ops['<$>'],
+				_Bogdanp$elm_ast$Ast_Statement$PortDeclaration,
+				A2(
+					_elm_community$parser_combinators$Combine_ops['*>'],
+					_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
+					_Bogdanp$elm_ast$Ast_Helpers$loName)),
+			_elm_community$parser_combinators$Combine$many(
+				A2(_Bogdanp$elm_ast$Ast_Helpers$between_, _Bogdanp$elm_ast$Ast_Helpers$spaces, _Bogdanp$elm_ast$Ast_Helpers$loName))),
 		A2(
 			_elm_community$parser_combinators$Combine_ops['*>'],
-			_Bogdanp$elm_ast$Ast_Helpers$symbol(':'),
-			_Bogdanp$elm_ast$Ast_Statement$typeAnnotation)));
-var _Bogdanp$elm_ast$Ast_Statement$TypeDeclaration = F3(
-	function (a, b, c) {
-		return {ctor: 'TypeDeclaration', _0: a, _1: b, _2: c};
+			_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
+			_Bogdanp$elm_ast$Ast_Expression$expression(ops)));
+};
+var _Bogdanp$elm_ast$Ast_Statement$PortTypeDeclaration = F2(
+	function (a, b) {
+		return {ctor: 'PortTypeDeclaration', _0: a, _1: b};
 	});
-var _Bogdanp$elm_ast$Ast_Statement$typeDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+var _Bogdanp$elm_ast$Ast_Statement$portTypeDeclaration = A2(
+	_elm_community$parser_combinators$Combine_ops['<*>'],
 	A2(
-		_elm_community$parser_combinators$Combine_ops['<*>'],
+		_elm_community$parser_combinators$Combine_ops['<$>'],
+		_Bogdanp$elm_ast$Ast_Statement$PortTypeDeclaration,
 		A2(
-			_elm_community$parser_combinators$Combine_ops['<$>'],
-			_Bogdanp$elm_ast$Ast_Statement$TypeDeclaration,
+			_elm_community$parser_combinators$Combine_ops['*>'],
+			_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
+			_Bogdanp$elm_ast$Ast_Helpers$loName)),
+	A2(
+		_elm_community$parser_combinators$Combine_ops['*>'],
+		_Bogdanp$elm_ast$Ast_Helpers$symbol(':'),
+		_Bogdanp$elm_ast$Ast_Statement$typeAnnotation));
+var _Bogdanp$elm_ast$Ast_Statement$TypeDeclaration = F2(
+	function (a, b) {
+		return {ctor: 'TypeDeclaration', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$typeDeclaration = A2(
+	_elm_community$parser_combinators$Combine_ops['<*>'],
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<$>'],
+		_Bogdanp$elm_ast$Ast_Statement$TypeDeclaration,
+		A2(
+			_elm_community$parser_combinators$Combine_ops['*>'],
+			_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('type'),
+			_Bogdanp$elm_ast$Ast_Statement$type_)),
+	A2(
+		_elm_community$parser_combinators$Combine_ops['*>'],
+		A2(
+			_elm_community$parser_combinators$Combine_ops['*>'],
+			_elm_community$parser_combinators$Combine$whitespace,
+			_Bogdanp$elm_ast$Ast_Helpers$symbol('=')),
+		A2(
+			_elm_community$parser_combinators$Combine$sepBy1,
+			_Bogdanp$elm_ast$Ast_Helpers$symbol('|'),
+			A2(_Bogdanp$elm_ast$Ast_Helpers$between_, _elm_community$parser_combinators$Combine$whitespace, _Bogdanp$elm_ast$Ast_Statement$typeConstructor))));
+var _Bogdanp$elm_ast$Ast_Statement$TypeAliasDeclaration = F2(
+	function (a, b) {
+		return {ctor: 'TypeAliasDeclaration', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$typeAliasDeclaration = A2(
+	_elm_community$parser_combinators$Combine_ops['<*>'],
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<$>'],
+		_Bogdanp$elm_ast$Ast_Statement$TypeAliasDeclaration,
+		A2(
+			_elm_community$parser_combinators$Combine_ops['*>'],
 			A2(
 				_elm_community$parser_combinators$Combine_ops['*>'],
 				_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('type'),
-				_Bogdanp$elm_ast$Ast_Statement$type_)),
+				_Bogdanp$elm_ast$Ast_Helpers$symbol('alias')),
+			_Bogdanp$elm_ast$Ast_Statement$type_)),
+	A2(
+		_elm_community$parser_combinators$Combine_ops['*>'],
 		A2(
 			_elm_community$parser_combinators$Combine_ops['*>'],
-			A2(
-				_elm_community$parser_combinators$Combine_ops['*>'],
-				_elm_community$parser_combinators$Combine$whitespace,
-				_Bogdanp$elm_ast$Ast_Helpers$symbol('=')),
-			A2(
-				_elm_community$parser_combinators$Combine$sepBy1,
-				_Bogdanp$elm_ast$Ast_Helpers$symbol('|'),
-				A2(_Bogdanp$elm_ast$Ast_Helpers$between_, _elm_community$parser_combinators$Combine$whitespace, _Bogdanp$elm_ast$Ast_Statement$typeConstructor)))));
-var _Bogdanp$elm_ast$Ast_Statement$TypeAliasDeclaration = F3(
+			_elm_community$parser_combinators$Combine$whitespace,
+			_Bogdanp$elm_ast$Ast_Helpers$symbol('=')),
+		_Bogdanp$elm_ast$Ast_Statement$typeAnnotation));
+var _Bogdanp$elm_ast$Ast_Statement$ImportStatement = F3(
 	function (a, b, c) {
-		return {ctor: 'TypeAliasDeclaration', _0: a, _1: b, _2: c};
+		return {ctor: 'ImportStatement', _0: a, _1: b, _2: c};
 	});
-var _Bogdanp$elm_ast$Ast_Statement$typeAliasDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+var _Bogdanp$elm_ast$Ast_Statement$importStatement = A2(
+	_elm_community$parser_combinators$Combine_ops['<*>'],
 	A2(
 		_elm_community$parser_combinators$Combine_ops['<*>'],
 		A2(
 			_elm_community$parser_combinators$Combine_ops['<$>'],
-			_Bogdanp$elm_ast$Ast_Statement$TypeAliasDeclaration,
+			_Bogdanp$elm_ast$Ast_Statement$ImportStatement,
 			A2(
 				_elm_community$parser_combinators$Combine_ops['*>'],
-				A2(
-					_elm_community$parser_combinators$Combine_ops['*>'],
-					_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('type'),
-					_Bogdanp$elm_ast$Ast_Helpers$symbol('alias')),
-				_Bogdanp$elm_ast$Ast_Statement$type_)),
-		A2(
-			_elm_community$parser_combinators$Combine_ops['*>'],
-			A2(
-				_elm_community$parser_combinators$Combine_ops['*>'],
-				_elm_community$parser_combinators$Combine$whitespace,
-				_Bogdanp$elm_ast$Ast_Helpers$symbol('=')),
-			_Bogdanp$elm_ast$Ast_Statement$typeAnnotation)));
-var _Bogdanp$elm_ast$Ast_Statement$ImportStatement = F4(
-	function (a, b, c, d) {
-		return {ctor: 'ImportStatement', _0: a, _1: b, _2: c, _3: d};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$importStatement = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<*>'],
-		A2(
-			_elm_community$parser_combinators$Combine_ops['<*>'],
-			A2(
-				_elm_community$parser_combinators$Combine_ops['<$>'],
-				_Bogdanp$elm_ast$Ast_Statement$ImportStatement,
-				A2(
-					_elm_community$parser_combinators$Combine_ops['*>'],
-					_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('import'),
-					_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
-			_elm_community$parser_combinators$Combine$maybe(
-				A2(
-					_elm_community$parser_combinators$Combine_ops['*>'],
-					_Bogdanp$elm_ast$Ast_Helpers$symbol('as'),
-					_Bogdanp$elm_ast$Ast_Helpers$upName))),
+				_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('import'),
+				_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
 		_elm_community$parser_combinators$Combine$maybe(
 			A2(
 				_elm_community$parser_combinators$Combine_ops['*>'],
-				_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
-				_Bogdanp$elm_ast$Ast_Statement$exports))));
-var _Bogdanp$elm_ast$Ast_Statement$EffectModuleDeclaration = F4(
-	function (a, b, c, d) {
-		return {ctor: 'EffectModuleDeclaration', _0: a, _1: b, _2: c, _3: d};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$effectModuleDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<*>'],
-		A2(
-			_elm_community$parser_combinators$Combine_ops['<*>'],
-			A2(
-				_elm_community$parser_combinators$Combine_ops['<$>'],
-				_Bogdanp$elm_ast$Ast_Statement$EffectModuleDeclaration,
-				A2(
-					_elm_community$parser_combinators$Combine_ops['*>'],
-					A2(
-						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('effect'),
-						_Bogdanp$elm_ast$Ast_Helpers$symbol('module')),
-					_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
-			A2(
-				_elm_community$parser_combinators$Combine_ops['*>'],
-				_Bogdanp$elm_ast$Ast_Helpers$symbol('where'),
-				_elm_community$parser_combinators$Combine$braces(
-					_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
-						A2(
-							_elm_community$parser_combinators$Combine_ops['<*>'],
-							A2(
-								_elm_community$parser_combinators$Combine_ops['<$>'],
-								F2(
-									function (v0, v1) {
-										return {ctor: '_Tuple2', _0: v0, _1: v1};
-									}),
-								_Bogdanp$elm_ast$Ast_Helpers$loName),
-							A2(
-								_elm_community$parser_combinators$Combine_ops['*>'],
-								_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
-								_Bogdanp$elm_ast$Ast_Helpers$upName)))))),
+				_Bogdanp$elm_ast$Ast_Helpers$symbol('as'),
+				_Bogdanp$elm_ast$Ast_Helpers$upName))),
+	_elm_community$parser_combinators$Combine$maybe(
 		A2(
 			_elm_community$parser_combinators$Combine_ops['*>'],
 			_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
 			_Bogdanp$elm_ast$Ast_Statement$exports)));
-var _Bogdanp$elm_ast$Ast_Statement$PortModuleDeclaration = F3(
+var _Bogdanp$elm_ast$Ast_Statement$EffectModuleDeclaration = F3(
 	function (a, b, c) {
-		return {ctor: 'PortModuleDeclaration', _0: a, _1: b, _2: c};
+		return {ctor: 'EffectModuleDeclaration', _0: a, _1: b, _2: c};
 	});
-var _Bogdanp$elm_ast$Ast_Statement$portModuleDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+var _Bogdanp$elm_ast$Ast_Statement$effectModuleDeclaration = A2(
+	_elm_community$parser_combinators$Combine_ops['<*>'],
 	A2(
 		_elm_community$parser_combinators$Combine_ops['<*>'],
 		A2(
 			_elm_community$parser_combinators$Combine_ops['<$>'],
-			_Bogdanp$elm_ast$Ast_Statement$PortModuleDeclaration,
+			_Bogdanp$elm_ast$Ast_Statement$EffectModuleDeclaration,
 			A2(
 				_elm_community$parser_combinators$Combine_ops['*>'],
 				A2(
 					_elm_community$parser_combinators$Combine_ops['*>'],
-					_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
+					_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('effect'),
 					_Bogdanp$elm_ast$Ast_Helpers$symbol('module')),
 				_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
 		A2(
 			_elm_community$parser_combinators$Combine_ops['*>'],
-			_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
-			_Bogdanp$elm_ast$Ast_Statement$exports)));
-var _Bogdanp$elm_ast$Ast_Statement$ModuleDeclaration = F3(
-	function (a, b, c) {
-		return {ctor: 'ModuleDeclaration', _0: a, _1: b, _2: c};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$moduleDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+			_Bogdanp$elm_ast$Ast_Helpers$symbol('where'),
+			_elm_community$parser_combinators$Combine$braces(
+				_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
+					A2(
+						_elm_community$parser_combinators$Combine_ops['<*>'],
+						A2(
+							_elm_community$parser_combinators$Combine_ops['<$>'],
+							F2(
+								function (v0, v1) {
+									return {ctor: '_Tuple2', _0: v0, _1: v1};
+								}),
+							_Bogdanp$elm_ast$Ast_Helpers$loName),
+						A2(
+							_elm_community$parser_combinators$Combine_ops['*>'],
+							_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
+							_Bogdanp$elm_ast$Ast_Helpers$upName)))))),
 	A2(
-		_elm_community$parser_combinators$Combine_ops['<*>'],
-		A2(
-			_elm_community$parser_combinators$Combine_ops['<$>'],
-			_Bogdanp$elm_ast$Ast_Statement$ModuleDeclaration,
-			A2(
-				_elm_community$parser_combinators$Combine_ops['*>'],
-				_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('module'),
-				_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
+		_elm_community$parser_combinators$Combine_ops['*>'],
+		_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
+		_Bogdanp$elm_ast$Ast_Statement$exports));
+var _Bogdanp$elm_ast$Ast_Statement$PortModuleDeclaration = F2(
+	function (a, b) {
+		return {ctor: 'PortModuleDeclaration', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$portModuleDeclaration = A2(
+	_elm_community$parser_combinators$Combine_ops['<*>'],
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<$>'],
+		_Bogdanp$elm_ast$Ast_Statement$PortModuleDeclaration,
 		A2(
 			_elm_community$parser_combinators$Combine_ops['*>'],
-			_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
-			_Bogdanp$elm_ast$Ast_Statement$exports)));
+			A2(
+				_elm_community$parser_combinators$Combine_ops['*>'],
+				_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
+				_Bogdanp$elm_ast$Ast_Helpers$symbol('module')),
+			_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
+	A2(
+		_elm_community$parser_combinators$Combine_ops['*>'],
+		_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
+		_Bogdanp$elm_ast$Ast_Statement$exports));
+var _Bogdanp$elm_ast$Ast_Statement$ModuleDeclaration = F2(
+	function (a, b) {
+		return {ctor: 'ModuleDeclaration', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$moduleDeclaration = A2(
+	_elm_community$parser_combinators$Combine_ops['<*>'],
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<$>'],
+		_Bogdanp$elm_ast$Ast_Statement$ModuleDeclaration,
+		A2(
+			_elm_community$parser_combinators$Combine_ops['*>'],
+			_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('module'),
+			_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
+	A2(
+		_elm_community$parser_combinators$Combine_ops['*>'],
+		_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
+		_Bogdanp$elm_ast$Ast_Statement$exports));
 var _Bogdanp$elm_ast$Ast_Statement$statement = function (ops) {
-	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p21) {
-			var _p22 = _p21;
-			return _elm_community$parser_combinators$Combine$choice(
-				{
+	return _elm_community$parser_combinators$Combine$choice(
+		{
+			ctor: '::',
+			_0: _Bogdanp$elm_ast$Ast_Statement$portModuleDeclaration,
+			_1: {
+				ctor: '::',
+				_0: _Bogdanp$elm_ast$Ast_Statement$effectModuleDeclaration,
+				_1: {
 					ctor: '::',
-					_0: _Bogdanp$elm_ast$Ast_Statement$portModuleDeclaration,
+					_0: _Bogdanp$elm_ast$Ast_Statement$moduleDeclaration,
 					_1: {
 						ctor: '::',
-						_0: _Bogdanp$elm_ast$Ast_Statement$effectModuleDeclaration,
+						_0: _Bogdanp$elm_ast$Ast_Statement$importStatement,
 						_1: {
 							ctor: '::',
-							_0: _Bogdanp$elm_ast$Ast_Statement$moduleDeclaration,
+							_0: _Bogdanp$elm_ast$Ast_Statement$typeAliasDeclaration,
 							_1: {
 								ctor: '::',
-								_0: _Bogdanp$elm_ast$Ast_Statement$importStatement,
+								_0: _Bogdanp$elm_ast$Ast_Statement$typeDeclaration,
 								_1: {
 									ctor: '::',
-									_0: _Bogdanp$elm_ast$Ast_Statement$typeAliasDeclaration,
+									_0: _Bogdanp$elm_ast$Ast_Statement$portTypeDeclaration,
 									_1: {
 										ctor: '::',
-										_0: _Bogdanp$elm_ast$Ast_Statement$typeDeclaration,
+										_0: _Bogdanp$elm_ast$Ast_Statement$portDeclaration(ops),
 										_1: {
 											ctor: '::',
-											_0: _Bogdanp$elm_ast$Ast_Statement$portTypeDeclaration,
+											_0: _Bogdanp$elm_ast$Ast_Statement$functionTypeDeclaration,
 											_1: {
 												ctor: '::',
-												_0: _Bogdanp$elm_ast$Ast_Statement$portDeclaration(ops),
+												_0: _Bogdanp$elm_ast$Ast_Statement$functionDeclaration(ops),
 												_1: {
 													ctor: '::',
-													_0: _Bogdanp$elm_ast$Ast_Statement$functionTypeDeclaration,
+													_0: _Bogdanp$elm_ast$Ast_Statement$infixDeclaration,
 													_1: {
 														ctor: '::',
-														_0: _Bogdanp$elm_ast$Ast_Statement$functionDeclaration(ops),
-														_1: {
-															ctor: '::',
-															_0: _Bogdanp$elm_ast$Ast_Statement$infixDeclaration,
-															_1: {
-																ctor: '::',
-																_0: _Bogdanp$elm_ast$Ast_Statement$comment,
-																_1: {ctor: '[]'}
-															}
-														}
+														_0: _Bogdanp$elm_ast$Ast_Statement$comment,
+														_1: {ctor: '[]'}
 													}
 												}
 											}
@@ -8888,7 +8556,8 @@ var _Bogdanp$elm_ast$Ast_Statement$statement = function (ops) {
 							}
 						}
 					}
-				});
+				}
+			}
 		});
 };
 var _Bogdanp$elm_ast$Ast_Statement$statements = function (ops) {
@@ -12760,10 +12429,6 @@ var _elm_lang$html$Html_Events$Options = F2(
 		return {stopPropagation: a, preventDefault: b};
 	});
 
-var _Bogdanp$elm_ast$Main$toText = function (_p0) {
-	return _elm_lang$html$Html$text(
-		_elm_lang$core$Basics$toString(_p0));
-};
 var _Bogdanp$elm_ast$Main$withChild = F2(
 	function (title, children) {
 		return A2(
@@ -12776,7 +12441,8 @@ var _Bogdanp$elm_ast$Main$withChild = F2(
 					{ctor: '[]'},
 					{
 						ctor: '::',
-						_0: _Bogdanp$elm_ast$Main$toText(title),
+						_0: _elm_lang$html$Html$text(
+							_elm_lang$core$Basics$toString(title)),
 						_1: {ctor: '[]'}
 					}),
 				_1: {
@@ -12790,23 +12456,23 @@ var _Bogdanp$elm_ast$Main$withChild = F2(
 			});
 	});
 var _Bogdanp$elm_ast$Main$expression = function (e) {
-	var _p1 = e;
-	switch (_p1.ctor) {
+	var _p0 = e;
+	switch (_p0.ctor) {
 		case 'List':
 			return A2(
 				_Bogdanp$elm_ast$Main$withChild,
 				e,
-				A2(_elm_lang$core$List$map, _Bogdanp$elm_ast$Main$expression, _p1._0));
+				A2(_elm_lang$core$List$map, _Bogdanp$elm_ast$Main$expression, _p0._0));
 		case 'Application':
 			return A2(
 				_Bogdanp$elm_ast$Main$withChild,
 				e,
 				{
 					ctor: '::',
-					_0: _Bogdanp$elm_ast$Main$expression(_p1._0),
+					_0: _Bogdanp$elm_ast$Main$expression(_p0._0),
 					_1: {
 						ctor: '::',
-						_0: _Bogdanp$elm_ast$Main$expression(_p1._1),
+						_0: _Bogdanp$elm_ast$Main$expression(_p0._1),
 						_1: {ctor: '[]'}
 					}
 				});
@@ -12821,7 +12487,8 @@ var _Bogdanp$elm_ast$Main$expression = function (e) {
 						{ctor: '[]'},
 						{
 							ctor: '::',
-							_0: _Bogdanp$elm_ast$Main$toText(_p1),
+							_0: _elm_lang$html$Html$text(
+								_elm_lang$core$Basics$toString(_p0)),
 							_1: {ctor: '[]'}
 						}),
 					_1: {ctor: '[]'}
@@ -12829,14 +12496,14 @@ var _Bogdanp$elm_ast$Main$expression = function (e) {
 	}
 };
 var _Bogdanp$elm_ast$Main$statement = function (s) {
-	var _p2 = s;
-	if (_p2.ctor === 'FunctionDeclaration') {
+	var _p1 = s;
+	if (_p1.ctor === 'FunctionDeclaration') {
 		return A2(
 			_Bogdanp$elm_ast$Main$withChild,
 			s,
 			{
 				ctor: '::',
-				_0: _Bogdanp$elm_ast$Main$expression(_p2._2),
+				_0: _Bogdanp$elm_ast$Main$expression(_p1._2),
 				_1: {ctor: '[]'}
 			});
 	} else {
@@ -12850,7 +12517,8 @@ var _Bogdanp$elm_ast$Main$statement = function (s) {
 					{ctor: '[]'},
 					{
 						ctor: '::',
-						_0: _Bogdanp$elm_ast$Main$toText(_p2),
+						_0: _elm_lang$html$Html$text(
+							_elm_lang$core$Basics$toString(_p1)),
 						_1: {ctor: '[]'}
 					}),
 				_1: {ctor: '[]'}
@@ -12858,27 +12526,28 @@ var _Bogdanp$elm_ast$Main$statement = function (s) {
 	}
 };
 var _Bogdanp$elm_ast$Main$tree = function (m) {
-	var _p3 = _Bogdanp$elm_ast$Ast$parse(m);
-	if ((_p3.ctor === 'Ok') && (_p3._0.ctor === '_Tuple3')) {
+	var _p2 = _Bogdanp$elm_ast$Ast$parse(m);
+	if ((_p2.ctor === 'Ok') && (_p2._0.ctor === '_Tuple3')) {
 		return A2(
 			_elm_lang$html$Html$ul,
 			{ctor: '[]'},
-			A2(_elm_lang$core$List$map, _Bogdanp$elm_ast$Main$statement, _p3._0._2));
+			A2(_elm_lang$core$List$map, _Bogdanp$elm_ast$Main$statement, _p2._0._2));
 	} else {
 		return A2(
 			_elm_lang$html$Html$div,
 			{ctor: '[]'},
 			{
 				ctor: '::',
-				_0: _Bogdanp$elm_ast$Main$toText(_p3),
+				_0: _elm_lang$html$Html$text(
+					_elm_lang$core$Basics$toString(_p2)),
 				_1: {ctor: '[]'}
 			});
 	}
 };
 var _Bogdanp$elm_ast$Main$update = F2(
 	function (action, model) {
-		var _p4 = action;
-		return _p4._0;
+		var _p3 = action;
+		return _p3._0;
 	});
 var _Bogdanp$elm_ast$Main$init = 'module Main exposing (..)\n\nf : Int -> Int\nf x = x + 1\n\ng : Int -> Int\ng x = x * 2\n\nh = f << g\n';
 var _Bogdanp$elm_ast$Main$Replace = function (a) {

--- a/example/elm.js
+++ b/example/elm.js
@@ -5496,6 +5496,29 @@ var _Bogdanp$elm_ast$Ast_Helpers$loName = function () {
 		loName_);
 }();
 var _Bogdanp$elm_ast$Ast_Helpers$functionName = _Bogdanp$elm_ast$Ast_Helpers$loName;
+var _Bogdanp$elm_ast$Ast_Helpers$makeMeta = function (_p2) {
+	var _p3 = _p2;
+	var _p4 = _p3.column;
+	return {
+		line: _p3.line,
+		column: (_elm_lang$core$Native_Utils.cmp(_p4, 0) < 0) ? 0 : _p4
+	};
+};
+var _Bogdanp$elm_ast$Ast_Helpers$withMeta = function (p) {
+	return _elm_community$parser_combinators$Combine$withLocation(
+		function (_p5) {
+			return A3(
+				_elm_lang$core$Basics$flip,
+				_elm_community$parser_combinators$Combine$andMap,
+				p,
+				_elm_community$parser_combinators$Combine$succeed(
+					_Bogdanp$elm_ast$Ast_Helpers$makeMeta(_p5)));
+		});
+};
+var _Bogdanp$elm_ast$Ast_Helpers$Meta = F2(
+	function (a, b) {
+		return {line: a, column: b};
+	});
 
 var _Bogdanp$elm_ast$Ast_BinOp$R = {ctor: 'R'};
 var _Bogdanp$elm_ast$Ast_BinOp$L = {ctor: 'L'};
@@ -7336,49 +7359,6 @@ var _Bogdanp$elm_ast$Ast_Expression$Application = F2(
 	function (a, b) {
 		return {ctor: 'Application', _0: a, _1: b};
 	});
-var _Bogdanp$elm_ast$Ast_Expression$Lambda = F2(
-	function (a, b) {
-		return {ctor: 'Lambda', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$Case = F2(
-	function (a, b) {
-		return {ctor: 'Case', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$Let = F2(
-	function (a, b) {
-		return {ctor: 'Let', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$If = F3(
-	function (a, b, c) {
-		return {ctor: 'If', _0: a, _1: b, _2: c};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$RecordUpdate = F2(
-	function (a, b) {
-		return {ctor: 'RecordUpdate', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$Record = function (a) {
-	return {ctor: 'Record', _0: a};
-};
-var _Bogdanp$elm_ast$Ast_Expression$AccessFunction = function (a) {
-	return {ctor: 'AccessFunction', _0: a};
-};
-var _Bogdanp$elm_ast$Ast_Expression$accessFunction = A2(
-	_elm_community$parser_combinators$Combine_ops['<$>'],
-	_Bogdanp$elm_ast$Ast_Expression$AccessFunction,
-	A2(
-		_elm_community$parser_combinators$Combine_ops['*>'],
-		_elm_community$parser_combinators$Combine$string('.'),
-		_Bogdanp$elm_ast$Ast_Helpers$loName));
-var _Bogdanp$elm_ast$Ast_Expression$Access = F2(
-	function (a, b) {
-		return {ctor: 'Access', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Expression$Tuple = function (a) {
-	return {ctor: 'Tuple', _0: a};
-};
-var _Bogdanp$elm_ast$Ast_Expression$List = function (a) {
-	return {ctor: 'List', _0: a};
-};
 var _Bogdanp$elm_ast$Ast_Expression$Variable = function (a) {
 	return {ctor: 'Variable', _0: a};
 };
@@ -7417,78 +7397,46 @@ var _Bogdanp$elm_ast$Ast_Expression$variable = A2(
 				}
 			}
 		}));
-var _Bogdanp$elm_ast$Ast_Expression$access = A2(
-	_elm_community$parser_combinators$Combine_ops['<*>'],
-	A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Access, _Bogdanp$elm_ast$Ast_Expression$variable),
-	_elm_community$parser_combinators$Combine$many1(
-		A2(
-			_elm_community$parser_combinators$Combine_ops['*>'],
-			_elm_community$parser_combinators$Combine$string('.'),
-			_Bogdanp$elm_ast$Ast_Helpers$loName)));
-var _Bogdanp$elm_ast$Ast_Expression$simplifiedRecord = _elm_community$parser_combinators$Combine$lazy(
-	function (_p7) {
-		var _p8 = _p7;
-		return A2(
-			_elm_community$parser_combinators$Combine_ops['<$>'],
-			_Bogdanp$elm_ast$Ast_Expression$Record,
-			_elm_community$parser_combinators$Combine$braces(
-				_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
-					A2(
-						_elm_community$parser_combinators$Combine_ops['<$>'],
-						function (a) {
-							return {
-								ctor: '_Tuple2',
-								_0: a,
-								_1: _Bogdanp$elm_ast$Ast_Expression$Variable(
-									{
-										ctor: '::',
-										_0: a,
-										_1: {ctor: '[]'}
-									})
-							};
-						},
-						_Bogdanp$elm_ast$Ast_Helpers$loName))));
-	});
 var _Bogdanp$elm_ast$Ast_Expression$joinL = F2(
 	function (es, ops) {
 		joinL:
 		while (true) {
-			var _p9 = {ctor: '_Tuple2', _0: es, _1: ops};
-			_v5_2:
+			var _p7 = {ctor: '_Tuple2', _0: es, _1: ops};
+			_v4_2:
 			do {
-				if ((_p9.ctor === '_Tuple2') && (_p9._0.ctor === '::')) {
-					if (_p9._0._1.ctor === '[]') {
-						if (_p9._1.ctor === '[]') {
-							return _elm_community$parser_combinators$Combine$succeed(_p9._0._0);
+				if ((_p7.ctor === '_Tuple2') && (_p7._0.ctor === '::')) {
+					if (_p7._0._1.ctor === '[]') {
+						if (_p7._1.ctor === '[]') {
+							return _elm_community$parser_combinators$Combine$succeed(_p7._0._0);
 						} else {
-							break _v5_2;
+							break _v4_2;
 						}
 					} else {
-						if (_p9._1.ctor === '::') {
-							var _v6 = {
+						if (_p7._1.ctor === '::') {
+							var _v5 = {
 								ctor: '::',
 								_0: A3(
 									_Bogdanp$elm_ast$Ast_Expression$BinOp,
 									_Bogdanp$elm_ast$Ast_Expression$Variable(
 										{
 											ctor: '::',
-											_0: _p9._1._0,
+											_0: _p7._1._0,
 											_1: {ctor: '[]'}
 										}),
-									_p9._0._0,
-									_p9._0._1._0),
-								_1: _p9._0._1._1
+									_p7._0._0,
+									_p7._0._1._0),
+								_1: _p7._0._1._1
 							},
-								_v7 = _p9._1._1;
-							es = _v6;
-							ops = _v7;
+								_v6 = _p7._1._1;
+							es = _v5;
+							ops = _v6;
 							continue joinL;
 						} else {
-							break _v5_2;
+							break _v4_2;
 						}
 					}
 				} else {
-					break _v5_2;
+					break _v4_2;
 				}
 			} while(false);
 			return _elm_community$parser_combinators$Combine$fail('');
@@ -7496,20 +7444,24 @@ var _Bogdanp$elm_ast$Ast_Expression$joinL = F2(
 	});
 var _Bogdanp$elm_ast$Ast_Expression$joinR = F2(
 	function (es, ops) {
-		var _p10 = {ctor: '_Tuple2', _0: es, _1: ops};
-		_v8_2:
+		var _p8 = {ctor: '_Tuple2', _0: es, _1: ops};
+		_v7_2:
 		do {
-			if ((_p10.ctor === '_Tuple2') && (_p10._0.ctor === '::')) {
-				if (_p10._0._1.ctor === '[]') {
-					if (_p10._1.ctor === '[]') {
-						return _elm_community$parser_combinators$Combine$succeed(_p10._0._0);
+			if ((_p8.ctor === '_Tuple2') && (_p8._0.ctor === '::')) {
+				if (_p8._0._1.ctor === '[]') {
+					if (_p8._1.ctor === '[]') {
+						return _elm_community$parser_combinators$Combine$succeed(_p8._0._0);
 					} else {
-						break _v8_2;
+						break _v7_2;
 					}
 				} else {
-					if (_p10._1.ctor === '::') {
+					if (_p8._1.ctor === '::') {
 						return A2(
-							_elm_community$parser_combinators$Combine$andThen,
+							_elm_community$parser_combinators$Combine_ops['>>='],
+							A2(
+								_Bogdanp$elm_ast$Ast_Expression$joinR,
+								{ctor: '::', _0: _p8._0._1._0, _1: _p8._0._1._1},
+								_p8._1._1),
 							function (e) {
 								return _elm_community$parser_combinators$Combine$succeed(
 									A3(
@@ -7517,30 +7469,26 @@ var _Bogdanp$elm_ast$Ast_Expression$joinR = F2(
 										_Bogdanp$elm_ast$Ast_Expression$Variable(
 											{
 												ctor: '::',
-												_0: _p10._1._0,
+												_0: _p8._1._0,
 												_1: {ctor: '[]'}
 											}),
-										_p10._0._0,
+										_p8._0._0,
 										e));
-							},
-							A2(
-								_Bogdanp$elm_ast$Ast_Expression$joinR,
-								{ctor: '::', _0: _p10._0._1._0, _1: _p10._0._1._1},
-								_p10._1._1));
+							});
 					} else {
-						break _v8_2;
+						break _v7_2;
 					}
 				}
 			} else {
-				break _v8_2;
+				break _v7_2;
 			}
 		} while(false);
 		return _elm_community$parser_combinators$Combine$fail('');
 	});
 var _Bogdanp$elm_ast$Ast_Expression$split = F4(
 	function (ops, l, e, eops) {
-		var _p11 = eops;
-		if (_p11.ctor === '[]') {
+		var _p9 = eops;
+		if (_p9.ctor === '[]') {
 			return _elm_community$parser_combinators$Combine$succeed(e);
 		} else {
 			return A2(
@@ -7559,8 +7507,8 @@ var _Bogdanp$elm_ast$Ast_Expression$split = F4(
 										_elm_lang$core$Tuple$first(x)) : _elm_lang$core$Maybe$Nothing;
 								},
 								eops);
-							var _p12 = assoc;
-							if (_p12.ctor === 'R') {
+							var _p10 = assoc;
+							if (_p10.ctor === 'R') {
 								return A2(_Bogdanp$elm_ast$Ast_Expression$joinR, es, ops_);
 							} else {
 								return A2(_Bogdanp$elm_ast$Ast_Expression$joinL, es, ops_);
@@ -7571,35 +7519,122 @@ var _Bogdanp$elm_ast$Ast_Expression$split = F4(
 	});
 var _Bogdanp$elm_ast$Ast_Expression$splitLevel = F4(
 	function (ops, l, e, eops) {
-		var _p13 = A2(
+		var _p11 = A2(
 			_elm_community$list_extra$List_Extra$break,
 			A2(_Bogdanp$elm_ast$Ast_Expression$hasLevel, ops, l),
 			eops);
-		if (_p13._1.ctor === '::') {
+		if (_p11._1.ctor === '::') {
 			return {
 				ctor: '::',
-				_0: A4(_Bogdanp$elm_ast$Ast_Expression$split, ops, l + 1, e, _p13._0),
-				_1: A4(_Bogdanp$elm_ast$Ast_Expression$splitLevel, ops, l, _p13._1._0._1, _p13._1._1)
+				_0: A4(_Bogdanp$elm_ast$Ast_Expression$split, ops, l + 1, e, _p11._0),
+				_1: A4(_Bogdanp$elm_ast$Ast_Expression$splitLevel, ops, l, _p11._1._0._1, _p11._1._1)
 			};
 		} else {
 			return {
 				ctor: '::',
-				_0: A4(_Bogdanp$elm_ast$Ast_Expression$split, ops, l + 1, e, _p13._0),
+				_0: A4(_Bogdanp$elm_ast$Ast_Expression$split, ops, l + 1, e, _p11._0),
 				_1: {ctor: '[]'}
 			};
 		}
 	});
-var _Bogdanp$elm_ast$Ast_Expression$Float = function (a) {
-	return {ctor: 'Float', _0: a};
-};
-var _Bogdanp$elm_ast$Ast_Expression$float = A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Float, _elm_community$parser_combinators$Combine_Num$float);
-var _Bogdanp$elm_ast$Ast_Expression$Integer = function (a) {
-	return {ctor: 'Integer', _0: a};
-};
-var _Bogdanp$elm_ast$Ast_Expression$integer = A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Integer, _elm_community$parser_combinators$Combine_Num$int);
-var _Bogdanp$elm_ast$Ast_Expression$String = function (a) {
-	return {ctor: 'String', _0: a};
-};
+var _Bogdanp$elm_ast$Ast_Expression$Lambda = F3(
+	function (a, b, c) {
+		return {ctor: 'Lambda', _0: a, _1: b, _2: c};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$Case = F3(
+	function (a, b, c) {
+		return {ctor: 'Case', _0: a, _1: b, _2: c};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$Let = F3(
+	function (a, b, c) {
+		return {ctor: 'Let', _0: a, _1: b, _2: c};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$If = F4(
+	function (a, b, c, d) {
+		return {ctor: 'If', _0: a, _1: b, _2: c, _3: d};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$RecordUpdate = F3(
+	function (a, b, c) {
+		return {ctor: 'RecordUpdate', _0: a, _1: b, _2: c};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$Record = F2(
+	function (a, b) {
+		return {ctor: 'Record', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$simplifiedRecord = _elm_community$parser_combinators$Combine$lazy(
+	function (_p12) {
+		var _p13 = _p12;
+		return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+			A2(
+				_elm_community$parser_combinators$Combine_ops['<$>'],
+				_Bogdanp$elm_ast$Ast_Expression$Record,
+				_elm_community$parser_combinators$Combine$braces(
+					_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
+						A2(
+							_elm_community$parser_combinators$Combine_ops['<$>'],
+							function (a) {
+								return {
+									ctor: '_Tuple2',
+									_0: a,
+									_1: _Bogdanp$elm_ast$Ast_Expression$Variable(
+										{
+											ctor: '::',
+											_0: a,
+											_1: {ctor: '[]'}
+										})
+								};
+							},
+							_Bogdanp$elm_ast$Ast_Helpers$loName)))));
+	});
+var _Bogdanp$elm_ast$Ast_Expression$AccessFunction = F2(
+	function (a, b) {
+		return {ctor: 'AccessFunction', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$accessFunction = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<$>'],
+		_Bogdanp$elm_ast$Ast_Expression$AccessFunction,
+		A2(
+			_elm_community$parser_combinators$Combine_ops['*>'],
+			_elm_community$parser_combinators$Combine$string('.'),
+			_Bogdanp$elm_ast$Ast_Helpers$loName)));
+var _Bogdanp$elm_ast$Ast_Expression$Access = F3(
+	function (a, b, c) {
+		return {ctor: 'Access', _0: a, _1: b, _2: c};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$access = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<*>'],
+		A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Access, _Bogdanp$elm_ast$Ast_Expression$variable),
+		_elm_community$parser_combinators$Combine$many1(
+			A2(
+				_elm_community$parser_combinators$Combine_ops['*>'],
+				_elm_community$parser_combinators$Combine$string('.'),
+				_Bogdanp$elm_ast$Ast_Helpers$loName))));
+var _Bogdanp$elm_ast$Ast_Expression$Tuple = F2(
+	function (a, b) {
+		return {ctor: 'Tuple', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$List = F2(
+	function (a, b) {
+		return {ctor: 'List', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$Float = F2(
+	function (a, b) {
+		return {ctor: 'Float', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$float = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Float, _elm_community$parser_combinators$Combine_Num$float));
+var _Bogdanp$elm_ast$Ast_Expression$Integer = F2(
+	function (a, b) {
+		return {ctor: 'Integer', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$integer = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	A2(_elm_community$parser_combinators$Combine_ops['<$>'], _Bogdanp$elm_ast$Ast_Expression$Integer, _elm_community$parser_combinators$Combine_Num$int));
+var _Bogdanp$elm_ast$Ast_Expression$String = F2(
+	function (a, b) {
+		return {ctor: 'String', _0: a, _1: b};
+	});
 var _Bogdanp$elm_ast$Ast_Expression$string = function () {
 	var multiString = A2(
 		_elm_community$parser_combinators$Combine_ops['<$>'],
@@ -7625,96 +7660,99 @@ var _Bogdanp$elm_ast$Ast_Expression$string = function () {
 				_elm_community$parser_combinators$Combine$string('\"'),
 				_elm_community$parser_combinators$Combine$regex('(\\\\\\\\|\\\\\"|[^\"\n])*')),
 			_elm_community$parser_combinators$Combine$string('\"')));
-	return A2(_elm_community$parser_combinators$Combine_ops['<|>'], multiString, singleString);
+	return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+		A2(_elm_community$parser_combinators$Combine_ops['<|>'], multiString, singleString));
 }();
-var _Bogdanp$elm_ast$Ast_Expression$Character = function (a) {
-	return {ctor: 'Character', _0: a};
-};
-var _Bogdanp$elm_ast$Ast_Expression$character = A2(
-	_elm_community$parser_combinators$Combine_ops['<$>'],
-	_Bogdanp$elm_ast$Ast_Expression$Character,
+var _Bogdanp$elm_ast$Ast_Expression$Character = F2(
+	function (a, b) {
+		return {ctor: 'Character', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Expression$character = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 	A2(
-		_Bogdanp$elm_ast$Ast_Helpers$between_,
-		_elm_community$parser_combinators$Combine$string('\''),
+		_elm_community$parser_combinators$Combine_ops['<$>'],
+		_Bogdanp$elm_ast$Ast_Expression$Character,
 		A2(
-			_elm_community$parser_combinators$Combine_ops['<|>'],
+			_Bogdanp$elm_ast$Ast_Helpers$between_,
+			_elm_community$parser_combinators$Combine$string('\''),
 			A2(
-				_elm_community$parser_combinators$Combine_ops['>>='],
+				_elm_community$parser_combinators$Combine_ops['<|>'],
 				A2(
-					_elm_community$parser_combinators$Combine_ops['*>'],
-					_elm_community$parser_combinators$Combine$string('\\'),
-					_elm_community$parser_combinators$Combine$regex('(n|t|r|\\\\|x..)')),
-				function (a) {
-					var _p15 = _elm_lang$core$String$uncons(a);
-					_v12_6:
-					do {
-						if (_p15.ctor === 'Just') {
-							if (_p15._0.ctor === '_Tuple2') {
-								switch (_p15._0._0.valueOf()) {
-									case 'n':
-										if (_p15._0._1 === '') {
-											return _elm_community$parser_combinators$Combine$succeed(
-												_elm_lang$core$Native_Utils.chr('\n'));
-										} else {
-											break _v12_6;
-										}
-									case 't':
-										if (_p15._0._1 === '') {
-											return _elm_community$parser_combinators$Combine$succeed(
-												_elm_lang$core$Native_Utils.chr('\t'));
-										} else {
-											break _v12_6;
-										}
-									case 'r':
-										if (_p15._0._1 === '') {
-											return _elm_community$parser_combinators$Combine$succeed(
-												_elm_lang$core$Native_Utils.chr('\r'));
-										} else {
-											break _v12_6;
-										}
-									case '\\':
-										if (_p15._0._1 === '') {
-											return _elm_community$parser_combinators$Combine$succeed(
-												_elm_lang$core$Native_Utils.chr('\\'));
-										} else {
-											break _v12_6;
-										}
-									case '0':
-										if (_p15._0._1 === '') {
-											return _elm_community$parser_combinators$Combine$succeed(
-												_elm_lang$core$Native_Utils.chr(' '));
-										} else {
-											break _v12_6;
-										}
-									case 'x':
-										return A2(
-											_elm_lang$core$Result$withDefault,
-											_elm_community$parser_combinators$Combine$fail('Invalid charcode'),
-											A2(
-												_elm_lang$core$Result$map,
-												_elm_community$parser_combinators$Combine$succeed,
+					_elm_community$parser_combinators$Combine_ops['>>='],
+					A2(
+						_elm_community$parser_combinators$Combine_ops['*>'],
+						_elm_community$parser_combinators$Combine$string('\\'),
+						_elm_community$parser_combinators$Combine$regex('(n|t|r|\\\\|x..)')),
+					function (a) {
+						var _p15 = _elm_lang$core$String$uncons(a);
+						_v12_6:
+						do {
+							if (_p15.ctor === 'Just') {
+								if (_p15._0.ctor === '_Tuple2') {
+									switch (_p15._0._0.valueOf()) {
+										case 'n':
+											if (_p15._0._1 === '') {
+												return _elm_community$parser_combinators$Combine$succeed(
+													_elm_lang$core$Native_Utils.chr('\n'));
+											} else {
+												break _v12_6;
+											}
+										case 't':
+											if (_p15._0._1 === '') {
+												return _elm_community$parser_combinators$Combine$succeed(
+													_elm_lang$core$Native_Utils.chr('\t'));
+											} else {
+												break _v12_6;
+											}
+										case 'r':
+											if (_p15._0._1 === '') {
+												return _elm_community$parser_combinators$Combine$succeed(
+													_elm_lang$core$Native_Utils.chr('\r'));
+											} else {
+												break _v12_6;
+											}
+										case '\\':
+											if (_p15._0._1 === '') {
+												return _elm_community$parser_combinators$Combine$succeed(
+													_elm_lang$core$Native_Utils.chr('\\'));
+											} else {
+												break _v12_6;
+											}
+										case '0':
+											if (_p15._0._1 === '') {
+												return _elm_community$parser_combinators$Combine$succeed(
+													_elm_lang$core$Native_Utils.chr(' '));
+											} else {
+												break _v12_6;
+											}
+										case 'x':
+											return A2(
+												_elm_lang$core$Result$withDefault,
+												_elm_community$parser_combinators$Combine$fail('Invalid charcode'),
 												A2(
 													_elm_lang$core$Result$map,
-													_elm_lang$core$Char$fromCode,
-													_rtfeldman$hex$Hex$fromString(
-														_elm_lang$core$String$toLower(_p15._0._1)))));
-									default:
-										break _v12_6;
+													_elm_community$parser_combinators$Combine$succeed,
+													A2(
+														_elm_lang$core$Result$map,
+														_elm_lang$core$Char$fromCode,
+														_rtfeldman$hex$Hex$fromString(
+															_elm_lang$core$String$toLower(_p15._0._1)))));
+										default:
+											break _v12_6;
+									}
+								} else {
+									break _v12_6;
 								}
 							} else {
-								break _v12_6;
+								return _elm_community$parser_combinators$Combine$fail('No character');
 							}
-						} else {
-							return _elm_community$parser_combinators$Combine$fail('No character');
-						}
-					} while(false);
-					return _elm_community$parser_combinators$Combine$fail(
-						A2(
-							_elm_lang$core$Basics_ops['++'],
-							'No such character as \\',
-							_elm_lang$core$Basics$toString(_p15._0)));
-				}),
-			_elm_community$parser_combinators$Combine_Char$anyChar)));
+						} while(false);
+						return _elm_community$parser_combinators$Combine$fail(
+							A2(
+								_elm_lang$core$Basics_ops['++'],
+								'No such character as \\',
+								_elm_lang$core$Basics$toString(_p15._0)));
+					}),
+				_elm_community$parser_combinators$Combine_Char$anyChar))));
 var _Bogdanp$elm_ast$Ast_Expression$term = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
 		function (_p16) {
@@ -7722,47 +7760,47 @@ var _Bogdanp$elm_ast$Ast_Expression$term = function (ops) {
 			return _elm_community$parser_combinators$Combine$choice(
 				{
 					ctor: '::',
-					_0: _Bogdanp$elm_ast$Ast_Expression$variable,
+					_0: _Bogdanp$elm_ast$Ast_Expression$access,
 					_1: {
 						ctor: '::',
-						_0: _Bogdanp$elm_ast$Ast_Expression$string,
+						_0: _Bogdanp$elm_ast$Ast_Expression$variable,
 						_1: {
 							ctor: '::',
-							_0: _Bogdanp$elm_ast$Ast_Expression$float,
+							_0: _Bogdanp$elm_ast$Ast_Expression$accessFunction,
 							_1: {
 								ctor: '::',
-								_0: _Bogdanp$elm_ast$Ast_Expression$integer,
+								_0: _Bogdanp$elm_ast$Ast_Expression$string,
 								_1: {
 									ctor: '::',
-									_0: _Bogdanp$elm_ast$Ast_Expression$character,
+									_0: _Bogdanp$elm_ast$Ast_Expression$float,
 									_1: {
 										ctor: '::',
-										_0: _elm_community$parser_combinators$Combine$parens(
-											A2(
-												_Bogdanp$elm_ast$Ast_Helpers$between_,
-												_elm_community$parser_combinators$Combine$whitespace,
-												_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
+										_0: _Bogdanp$elm_ast$Ast_Expression$integer,
 										_1: {
 											ctor: '::',
-											_0: _Bogdanp$elm_ast$Ast_Expression$list(ops),
+											_0: _Bogdanp$elm_ast$Ast_Expression$character,
 											_1: {
 												ctor: '::',
-												_0: _Bogdanp$elm_ast$Ast_Expression$tuple(ops),
+												_0: _elm_community$parser_combinators$Combine$parens(
+													A2(
+														_Bogdanp$elm_ast$Ast_Helpers$between_,
+														_elm_community$parser_combinators$Combine$whitespace,
+														_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
 												_1: {
 													ctor: '::',
-													_0: _Bogdanp$elm_ast$Ast_Expression$recordUpdate(ops),
+													_0: _Bogdanp$elm_ast$Ast_Expression$list(ops),
 													_1: {
 														ctor: '::',
-														_0: _Bogdanp$elm_ast$Ast_Expression$record(ops),
+														_0: _Bogdanp$elm_ast$Ast_Expression$tuple(ops),
 														_1: {
 															ctor: '::',
-															_0: _Bogdanp$elm_ast$Ast_Expression$simplifiedRecord,
+															_0: _Bogdanp$elm_ast$Ast_Expression$recordUpdate(ops),
 															_1: {
 																ctor: '::',
-																_0: _Bogdanp$elm_ast$Ast_Expression$access,
+																_0: _Bogdanp$elm_ast$Ast_Expression$record(ops),
 																_1: {
 																	ctor: '::',
-																	_0: _Bogdanp$elm_ast$Ast_Expression$accessFunction,
+																	_0: _Bogdanp$elm_ast$Ast_Expression$simplifiedRecord,
 																	_1: {ctor: '[]'}
 																}
 															}
@@ -7875,12 +7913,7 @@ var _Bogdanp$elm_ast$Ast_Expression$binary = function (ops) {
 						_elm_community$parser_combinators$Combine_ops['>>='],
 						collect,
 						function (eops) {
-							return A4(
-								_Bogdanp$elm_ast$Ast_Expression$split,
-								ops,
-								0,
-								A2(_elm_lang$core$Debug$log, 'exp', e),
-								eops);
+							return A4(_Bogdanp$elm_ast$Ast_Expression$split, ops, 0, e, eops);
 						});
 				});
 		});
@@ -7982,144 +8015,116 @@ var _Bogdanp$elm_ast$Ast_Expression$caseExpression = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
 		function (_p38) {
 			var _p39 = _p38;
-			return A2(
-				_elm_community$parser_combinators$Combine_ops['<*>'],
+			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 				A2(
-					_elm_community$parser_combinators$Combine_ops['<$>'],
-					_Bogdanp$elm_ast$Ast_Expression$Case,
+					_elm_community$parser_combinators$Combine_ops['<*>'],
+					A2(
+						_elm_community$parser_combinators$Combine_ops['<$>'],
+						_Bogdanp$elm_ast$Ast_Expression$Case,
+						A2(
+							_elm_community$parser_combinators$Combine_ops['*>'],
+							_Bogdanp$elm_ast$Ast_Helpers$symbol('case'),
+							_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
 					A2(
 						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$symbol('case'),
-						_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
-				A2(
-					_elm_community$parser_combinators$Combine_ops['*>'],
-					_Bogdanp$elm_ast$Ast_Helpers$symbol('of'),
-					_elm_community$parser_combinators$Combine$many1(
-						_Bogdanp$elm_ast$Ast_Expression$caseBinding(ops))));
+						_Bogdanp$elm_ast$Ast_Helpers$symbol('of'),
+						_elm_community$parser_combinators$Combine$many1(
+							_Bogdanp$elm_ast$Ast_Expression$caseBinding(ops)))));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$ifExpression = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
 		function (_p40) {
 			var _p41 = _p40;
-			return A2(
-				_elm_community$parser_combinators$Combine_ops['<*>'],
+			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 				A2(
 					_elm_community$parser_combinators$Combine_ops['<*>'],
 					A2(
-						_elm_community$parser_combinators$Combine_ops['<$>'],
-						_Bogdanp$elm_ast$Ast_Expression$If,
+						_elm_community$parser_combinators$Combine_ops['<*>'],
+						A2(
+							_elm_community$parser_combinators$Combine_ops['<$>'],
+							_Bogdanp$elm_ast$Ast_Expression$If,
+							A2(
+								_elm_community$parser_combinators$Combine_ops['*>'],
+								_Bogdanp$elm_ast$Ast_Helpers$symbol('if'),
+								_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
 						A2(
 							_elm_community$parser_combinators$Combine_ops['*>'],
-							_Bogdanp$elm_ast$Ast_Helpers$symbol('if'),
+							_Bogdanp$elm_ast$Ast_Helpers$symbol('then'),
 							_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
 					A2(
 						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$symbol('then'),
-						_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
-				A2(
-					_elm_community$parser_combinators$Combine_ops['*>'],
-					_Bogdanp$elm_ast$Ast_Helpers$symbol('else'),
-					_Bogdanp$elm_ast$Ast_Expression$expression(ops)));
+						_Bogdanp$elm_ast$Ast_Helpers$symbol('else'),
+						_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$lambda = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
 		function (_p42) {
 			var _p43 = _p42;
-			return A2(
-				_elm_community$parser_combinators$Combine_ops['<*>'],
+			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 				A2(
-					_elm_community$parser_combinators$Combine_ops['<$>'],
-					_Bogdanp$elm_ast$Ast_Expression$Lambda,
+					_elm_community$parser_combinators$Combine_ops['<*>'],
+					A2(
+						_elm_community$parser_combinators$Combine_ops['<$>'],
+						_Bogdanp$elm_ast$Ast_Expression$Lambda,
+						A2(
+							_elm_community$parser_combinators$Combine_ops['*>'],
+							_Bogdanp$elm_ast$Ast_Helpers$symbol('\\'),
+							_elm_community$parser_combinators$Combine$many(
+								A2(
+									_Bogdanp$elm_ast$Ast_Helpers$between_,
+									_Bogdanp$elm_ast$Ast_Helpers$spaces,
+									_Bogdanp$elm_ast$Ast_Expression$term(ops))))),
 					A2(
 						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$symbol('\\'),
-						_elm_community$parser_combinators$Combine$many(
-							A2(
-								_Bogdanp$elm_ast$Ast_Helpers$between_,
-								_Bogdanp$elm_ast$Ast_Helpers$spaces,
-								_Bogdanp$elm_ast$Ast_Expression$term(ops))))),
-				A2(
-					_elm_community$parser_combinators$Combine_ops['*>'],
-					_Bogdanp$elm_ast$Ast_Helpers$symbol('->'),
-					_Bogdanp$elm_ast$Ast_Expression$expression(ops)));
+						_Bogdanp$elm_ast$Ast_Helpers$symbol('->'),
+						_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$letExpression = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
 		function (_p44) {
 			var _p45 = _p44;
-			return A2(
-				_elm_community$parser_combinators$Combine_ops['<*>'],
+			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 				A2(
-					_elm_community$parser_combinators$Combine_ops['<$>'],
-					_Bogdanp$elm_ast$Ast_Expression$Let,
+					_elm_community$parser_combinators$Combine_ops['<*>'],
+					A2(
+						_elm_community$parser_combinators$Combine_ops['<$>'],
+						_Bogdanp$elm_ast$Ast_Expression$Let,
+						A2(
+							_elm_community$parser_combinators$Combine_ops['*>'],
+							_Bogdanp$elm_ast$Ast_Helpers$symbol_('let'),
+							_elm_community$parser_combinators$Combine$many1(
+								_Bogdanp$elm_ast$Ast_Expression$letBinding(ops)))),
 					A2(
 						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$symbol_('let'),
-						_elm_community$parser_combinators$Combine$many1(
-							_Bogdanp$elm_ast$Ast_Expression$letBinding(ops)))),
-				A2(
-					_elm_community$parser_combinators$Combine_ops['*>'],
-					_Bogdanp$elm_ast$Ast_Helpers$symbol('in'),
-					_Bogdanp$elm_ast$Ast_Expression$expression(ops)));
+						_Bogdanp$elm_ast$Ast_Helpers$symbol('in'),
+						_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$list = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
 		function (_p46) {
 			var _p47 = _p46;
-			return A2(
-				_elm_community$parser_combinators$Combine_ops['<$>'],
-				_Bogdanp$elm_ast$Ast_Expression$List,
-				_elm_community$parser_combinators$Combine$brackets(
-					_Bogdanp$elm_ast$Ast_Helpers$commaSeparated_(
-						_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
+			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+				A2(
+					_elm_community$parser_combinators$Combine_ops['<$>'],
+					_Bogdanp$elm_ast$Ast_Expression$List,
+					_elm_community$parser_combinators$Combine$brackets(
+						_Bogdanp$elm_ast$Ast_Helpers$commaSeparated_(
+							_Bogdanp$elm_ast$Ast_Expression$expression(ops)))));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$record = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
 		function (_p48) {
 			var _p49 = _p48;
-			return A2(
-				_elm_community$parser_combinators$Combine_ops['<$>'],
-				_Bogdanp$elm_ast$Ast_Expression$Record,
-				_elm_community$parser_combinators$Combine$braces(
-					_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
-						A2(
-							_elm_community$parser_combinators$Combine_ops['<*>'],
-							A2(
-								_elm_community$parser_combinators$Combine_ops['<$>'],
-								F2(
-									function (v0, v1) {
-										return {ctor: '_Tuple2', _0: v0, _1: v1};
-									}),
-								_Bogdanp$elm_ast$Ast_Helpers$loName),
-							A2(
-								_elm_community$parser_combinators$Combine_ops['*>'],
-								_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
-								_Bogdanp$elm_ast$Ast_Expression$expression(ops))))));
-		});
-};
-var _Bogdanp$elm_ast$Ast_Expression$recordUpdate = function (ops) {
-	return _elm_community$parser_combinators$Combine$lazy(
-		function (_p50) {
-			var _p51 = _p50;
-			return A2(
-				_elm_community$parser_combinators$Combine_ops['<*>'],
+			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 				A2(
 					_elm_community$parser_combinators$Combine_ops['<$>'],
-					_Bogdanp$elm_ast$Ast_Expression$RecordUpdate,
-					A2(
-						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$symbol('{'),
-						_Bogdanp$elm_ast$Ast_Helpers$loName)),
-				A2(
-					_elm_community$parser_combinators$Combine_ops['<*'],
-					A2(
-						_elm_community$parser_combinators$Combine_ops['*>'],
-						_Bogdanp$elm_ast$Ast_Helpers$symbol('|'),
+					_Bogdanp$elm_ast$Ast_Expression$Record,
+					_elm_community$parser_combinators$Combine$braces(
 						_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
 							A2(
 								_elm_community$parser_combinators$Combine_ops['<*>'],
@@ -8133,30 +8138,66 @@ var _Bogdanp$elm_ast$Ast_Expression$recordUpdate = function (ops) {
 								A2(
 									_elm_community$parser_combinators$Combine_ops['*>'],
 									_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
-									_Bogdanp$elm_ast$Ast_Expression$expression(ops))))),
-					_Bogdanp$elm_ast$Ast_Helpers$symbol('}')));
+									_Bogdanp$elm_ast$Ast_Expression$expression(ops)))))));
+		});
+};
+var _Bogdanp$elm_ast$Ast_Expression$recordUpdate = function (ops) {
+	return _elm_community$parser_combinators$Combine$lazy(
+		function (_p50) {
+			var _p51 = _p50;
+			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+				A2(
+					_elm_community$parser_combinators$Combine_ops['<*>'],
+					A2(
+						_elm_community$parser_combinators$Combine_ops['<$>'],
+						_Bogdanp$elm_ast$Ast_Expression$RecordUpdate,
+						A2(
+							_elm_community$parser_combinators$Combine_ops['*>'],
+							_Bogdanp$elm_ast$Ast_Helpers$symbol('{'),
+							_Bogdanp$elm_ast$Ast_Helpers$loName)),
+					A2(
+						_elm_community$parser_combinators$Combine_ops['<*'],
+						A2(
+							_elm_community$parser_combinators$Combine_ops['*>'],
+							_Bogdanp$elm_ast$Ast_Helpers$symbol('|'),
+							_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
+								A2(
+									_elm_community$parser_combinators$Combine_ops['<*>'],
+									A2(
+										_elm_community$parser_combinators$Combine_ops['<$>'],
+										F2(
+											function (v0, v1) {
+												return {ctor: '_Tuple2', _0: v0, _1: v1};
+											}),
+										_Bogdanp$elm_ast$Ast_Helpers$loName),
+									A2(
+										_elm_community$parser_combinators$Combine_ops['*>'],
+										_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
+										_Bogdanp$elm_ast$Ast_Expression$expression(ops))))),
+						_Bogdanp$elm_ast$Ast_Helpers$symbol('}'))));
 		});
 };
 var _Bogdanp$elm_ast$Ast_Expression$tuple = function (ops) {
 	return _elm_community$parser_combinators$Combine$lazy(
 		function (_p52) {
 			var _p53 = _p52;
-			return A2(
-				_elm_community$parser_combinators$Combine_ops['<$>'],
-				_Bogdanp$elm_ast$Ast_Expression$Tuple,
+			return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 				A2(
-					_elm_community$parser_combinators$Combine_ops['>>='],
-					_elm_community$parser_combinators$Combine$parens(
-						_Bogdanp$elm_ast$Ast_Helpers$commaSeparated_(
-							_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
-					function (a) {
-						var _p54 = a;
-						if ((_p54.ctor === '::') && (_p54._1.ctor === '[]')) {
-							return _elm_community$parser_combinators$Combine$fail('No single tuples');
-						} else {
-							return _elm_community$parser_combinators$Combine$succeed(_p54);
-						}
-					}));
+					_elm_community$parser_combinators$Combine_ops['<$>'],
+					_Bogdanp$elm_ast$Ast_Expression$Tuple,
+					A2(
+						_elm_community$parser_combinators$Combine_ops['>>='],
+						_elm_community$parser_combinators$Combine$parens(
+							_Bogdanp$elm_ast$Ast_Helpers$commaSeparated_(
+								_Bogdanp$elm_ast$Ast_Expression$expression(ops))),
+						function (a) {
+							var _p54 = a;
+							if ((_p54.ctor === '::') && (_p54._1.ctor === '[]')) {
+								return _elm_community$parser_combinators$Combine$fail('No single tuples');
+							} else {
+								return _elm_community$parser_combinators$Combine$succeed(_p54);
+							}
+						})));
 		});
 };
 
@@ -8411,72 +8452,76 @@ var _Bogdanp$elm_ast$Ast_Statement$typeTuple = _elm_community$parser_combinators
 			_elm_community$parser_combinators$Combine$parens(
 				_Bogdanp$elm_ast$Ast_Helpers$commaSeparated_(_Bogdanp$elm_ast$Ast_Statement$type_)));
 	});
-var _Bogdanp$elm_ast$Ast_Statement$Comment = function (a) {
-	return {ctor: 'Comment', _0: a};
-};
-var _Bogdanp$elm_ast$Ast_Statement$singleLineComment = A2(
-	_elm_community$parser_combinators$Combine_ops['<$>'],
-	_Bogdanp$elm_ast$Ast_Statement$Comment,
+var _Bogdanp$elm_ast$Ast_Statement$Comment = F2(
+	function (a, b) {
+		return {ctor: 'Comment', _0: a, _1: b};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$singleLineComment = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 	A2(
-		_elm_community$parser_combinators$Combine_ops['<*'],
+		_elm_community$parser_combinators$Combine_ops['<$>'],
+		_Bogdanp$elm_ast$Ast_Statement$Comment,
+		A2(
+			_elm_community$parser_combinators$Combine_ops['<*'],
+			A2(
+				_elm_community$parser_combinators$Combine_ops['*>'],
+				_elm_community$parser_combinators$Combine$string('--'),
+				_elm_community$parser_combinators$Combine$regex('.*')),
+			_elm_community$parser_combinators$Combine$whitespace)));
+var _Bogdanp$elm_ast$Ast_Statement$multiLineComment = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<$>'],
+		function (_p18) {
+			return _Bogdanp$elm_ast$Ast_Statement$Comment(
+				_elm_lang$core$String$fromList(_p18));
+		},
 		A2(
 			_elm_community$parser_combinators$Combine_ops['*>'],
-			_elm_community$parser_combinators$Combine$string('--'),
-			_elm_community$parser_combinators$Combine$regex('.*')),
-		_elm_community$parser_combinators$Combine$whitespace));
-var _Bogdanp$elm_ast$Ast_Statement$multiLineComment = A2(
-	_elm_community$parser_combinators$Combine_ops['<$>'],
-	function (_p18) {
-		return _Bogdanp$elm_ast$Ast_Statement$Comment(
-			_elm_lang$core$String$fromList(_p18));
-	},
-	A2(
-		_elm_community$parser_combinators$Combine_ops['*>'],
-		_elm_community$parser_combinators$Combine$string('{-'),
-		A2(
-			_elm_community$parser_combinators$Combine$manyTill,
-			_elm_community$parser_combinators$Combine_Char$anyChar,
-			_elm_community$parser_combinators$Combine$string('-}'))));
+			_elm_community$parser_combinators$Combine$string('{-'),
+			A2(
+				_elm_community$parser_combinators$Combine$manyTill,
+				_elm_community$parser_combinators$Combine_Char$anyChar,
+				_elm_community$parser_combinators$Combine$string('-}')))));
 var _Bogdanp$elm_ast$Ast_Statement$comment = A2(_elm_community$parser_combinators$Combine_ops['<|>'], _Bogdanp$elm_ast$Ast_Statement$singleLineComment, _Bogdanp$elm_ast$Ast_Statement$multiLineComment);
-var _Bogdanp$elm_ast$Ast_Statement$InfixDeclaration = F3(
-	function (a, b, c) {
-		return {ctor: 'InfixDeclaration', _0: a, _1: b, _2: c};
+var _Bogdanp$elm_ast$Ast_Statement$InfixDeclaration = F4(
+	function (a, b, c, d) {
+		return {ctor: 'InfixDeclaration', _0: a, _1: b, _2: c, _3: d};
 	});
-var _Bogdanp$elm_ast$Ast_Statement$infixDeclaration = A2(
-	_elm_community$parser_combinators$Combine_ops['<*>'],
+var _Bogdanp$elm_ast$Ast_Statement$infixDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 	A2(
 		_elm_community$parser_combinators$Combine_ops['<*>'],
 		A2(
-			_elm_community$parser_combinators$Combine_ops['<$>'],
-			_Bogdanp$elm_ast$Ast_Statement$InfixDeclaration,
-			_elm_community$parser_combinators$Combine$choice(
-				{
-					ctor: '::',
-					_0: A2(
-						_elm_community$parser_combinators$Combine_ops['<$'],
-						_Bogdanp$elm_ast$Ast_BinOp$L,
-						_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infixl')),
-					_1: {
+			_elm_community$parser_combinators$Combine_ops['<*>'],
+			A2(
+				_elm_community$parser_combinators$Combine_ops['<$>'],
+				_Bogdanp$elm_ast$Ast_Statement$InfixDeclaration,
+				_elm_community$parser_combinators$Combine$choice(
+					{
 						ctor: '::',
 						_0: A2(
 							_elm_community$parser_combinators$Combine_ops['<$'],
-							_Bogdanp$elm_ast$Ast_BinOp$R,
-							_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infixr')),
+							_Bogdanp$elm_ast$Ast_BinOp$L,
+							_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infixl')),
 						_1: {
 							ctor: '::',
 							_0: A2(
 								_elm_community$parser_combinators$Combine_ops['<$'],
-								_Bogdanp$elm_ast$Ast_BinOp$N,
-								_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infix')),
-							_1: {ctor: '[]'}
+								_Bogdanp$elm_ast$Ast_BinOp$R,
+								_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infixr')),
+							_1: {
+								ctor: '::',
+								_0: A2(
+									_elm_community$parser_combinators$Combine_ops['<$'],
+									_Bogdanp$elm_ast$Ast_BinOp$N,
+									_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('infix')),
+								_1: {ctor: '[]'}
+							}
 						}
-					}
-				})),
-		A2(_elm_community$parser_combinators$Combine_ops['*>'], _Bogdanp$elm_ast$Ast_Helpers$spaces, _elm_community$parser_combinators$Combine_Num$int)),
-	A2(
-		_elm_community$parser_combinators$Combine_ops['*>'],
-		_Bogdanp$elm_ast$Ast_Helpers$spaces,
-		A2(_elm_community$parser_combinators$Combine_ops['<|>'], _Bogdanp$elm_ast$Ast_Helpers$loName, _Bogdanp$elm_ast$Ast_Helpers$operator)));
+					})),
+			A2(_elm_community$parser_combinators$Combine_ops['*>'], _Bogdanp$elm_ast$Ast_Helpers$spaces, _elm_community$parser_combinators$Combine_Num$int)),
+		A2(
+			_elm_community$parser_combinators$Combine_ops['*>'],
+			_Bogdanp$elm_ast$Ast_Helpers$spaces,
+			A2(_elm_community$parser_combinators$Combine_ops['<|>'], _Bogdanp$elm_ast$Ast_Helpers$loName, _Bogdanp$elm_ast$Ast_Helpers$operator))));
 var _Bogdanp$elm_ast$Ast_Statement$infixStatements = function () {
 	var statements = A2(
 		_elm_community$parser_combinators$Combine_ops['<*'],
@@ -8499,12 +8544,12 @@ var _Bogdanp$elm_ast$Ast_Statement$infixStatements = function () {
 				_elm_community$parser_combinators$Combine$whitespace)),
 		_elm_community$parser_combinators$Combine$end);
 	return A2(
-		_elm_community$parser_combinators$Combine$andThen,
+		_elm_community$parser_combinators$Combine_ops['>>='],
+		statements,
 		function (xs) {
 			return _elm_community$parser_combinators$Combine$succeed(
 				A2(_elm_lang$core$List$filterMap, _elm_lang$core$Basics$identity, xs));
-		},
-		statements);
+		});
 }();
 var _Bogdanp$elm_ast$Ast_Statement$opTable = function (ops) {
 	var collect = F2(
@@ -8520,32 +8565,68 @@ var _Bogdanp$elm_ast$Ast_Statement$opTable = function (ops) {
 				return _elm_lang$core$Native_Utils.crashCase(
 					'Ast.Statement',
 					{
-						start: {line: 414, column: 13},
-						end: {line: 419, column: 45}
+						start: {line: 427, column: 13},
+						end: {line: 432, column: 45}
 					},
 					_p19)('impossible');
 			}
 		});
 	return A2(
-		_elm_community$parser_combinators$Combine$andThen,
+		_elm_community$parser_combinators$Combine_ops['>>='],
+		_Bogdanp$elm_ast$Ast_Statement$infixStatements,
 		function (xs) {
 			return _elm_community$parser_combinators$Combine$succeed(
 				A3(_elm_lang$core$List$foldr, collect, ops, xs));
-		},
-		_Bogdanp$elm_ast$Ast_Statement$infixStatements);
+		});
 };
-var _Bogdanp$elm_ast$Ast_Statement$FunctionDeclaration = F3(
-	function (a, b, c) {
-		return {ctor: 'FunctionDeclaration', _0: a, _1: b, _2: c};
+var _Bogdanp$elm_ast$Ast_Statement$FunctionDeclaration = F4(
+	function (a, b, c, d) {
+		return {ctor: 'FunctionDeclaration', _0: a, _1: b, _2: c, _3: d};
 	});
 var _Bogdanp$elm_ast$Ast_Statement$functionDeclaration = function (ops) {
-	return A2(
-		_elm_community$parser_combinators$Combine_ops['<*>'],
+	return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 		A2(
 			_elm_community$parser_combinators$Combine_ops['<*>'],
 			A2(
-				_elm_community$parser_combinators$Combine_ops['<$>'],
-				_Bogdanp$elm_ast$Ast_Statement$FunctionDeclaration,
+				_elm_community$parser_combinators$Combine_ops['<*>'],
+				A2(
+					_elm_community$parser_combinators$Combine_ops['<$>'],
+					_Bogdanp$elm_ast$Ast_Statement$FunctionDeclaration,
+					_elm_community$parser_combinators$Combine$choice(
+						{
+							ctor: '::',
+							_0: _Bogdanp$elm_ast$Ast_Helpers$loName,
+							_1: {
+								ctor: '::',
+								_0: _elm_community$parser_combinators$Combine$parens(_Bogdanp$elm_ast$Ast_Helpers$operator),
+								_1: {ctor: '[]'}
+							}
+						})),
+				_elm_community$parser_combinators$Combine$many(
+					A2(
+						_Bogdanp$elm_ast$Ast_Helpers$between_,
+						_elm_community$parser_combinators$Combine$whitespace,
+						_Bogdanp$elm_ast$Ast_Expression$term(ops)))),
+			A2(
+				_elm_community$parser_combinators$Combine_ops['*>'],
+				A2(
+					_elm_community$parser_combinators$Combine_ops['*>'],
+					_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
+					_elm_community$parser_combinators$Combine$whitespace),
+				_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
+};
+var _Bogdanp$elm_ast$Ast_Statement$FunctionTypeDeclaration = F3(
+	function (a, b, c) {
+		return {ctor: 'FunctionTypeDeclaration', _0: a, _1: b, _2: c};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$functionTypeDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<*>'],
+		A2(
+			_elm_community$parser_combinators$Combine_ops['<$>'],
+			_Bogdanp$elm_ast$Ast_Statement$FunctionTypeDeclaration,
+			A2(
+				_elm_community$parser_combinators$Combine_ops['<*'],
 				_elm_community$parser_combinators$Combine$choice(
 					{
 						ctor: '::',
@@ -8555,270 +8636,249 @@ var _Bogdanp$elm_ast$Ast_Statement$functionDeclaration = function (ops) {
 							_0: _elm_community$parser_combinators$Combine$parens(_Bogdanp$elm_ast$Ast_Helpers$operator),
 							_1: {ctor: '[]'}
 						}
-					})),
-			_elm_community$parser_combinators$Combine$many(
+					}),
+				_Bogdanp$elm_ast$Ast_Helpers$symbol(':'))),
+		_Bogdanp$elm_ast$Ast_Statement$typeAnnotation));
+var _Bogdanp$elm_ast$Ast_Statement$PortDeclaration = F4(
+	function (a, b, c, d) {
+		return {ctor: 'PortDeclaration', _0: a, _1: b, _2: c, _3: d};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$portDeclaration = function (ops) {
+	return _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+		A2(
+			_elm_community$parser_combinators$Combine_ops['<*>'],
+			A2(
+				_elm_community$parser_combinators$Combine_ops['<*>'],
 				A2(
-					_Bogdanp$elm_ast$Ast_Helpers$between_,
-					_elm_community$parser_combinators$Combine$whitespace,
-					_Bogdanp$elm_ast$Ast_Expression$term(ops)))),
+					_elm_community$parser_combinators$Combine_ops['<$>'],
+					_Bogdanp$elm_ast$Ast_Statement$PortDeclaration,
+					A2(
+						_elm_community$parser_combinators$Combine_ops['*>'],
+						_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
+						_Bogdanp$elm_ast$Ast_Helpers$loName)),
+				_elm_community$parser_combinators$Combine$many(
+					A2(_Bogdanp$elm_ast$Ast_Helpers$between_, _Bogdanp$elm_ast$Ast_Helpers$spaces, _Bogdanp$elm_ast$Ast_Helpers$loName))),
+			A2(
+				_elm_community$parser_combinators$Combine_ops['*>'],
+				_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
+				_Bogdanp$elm_ast$Ast_Expression$expression(ops))));
+};
+var _Bogdanp$elm_ast$Ast_Statement$PortTypeDeclaration = F3(
+	function (a, b, c) {
+		return {ctor: 'PortTypeDeclaration', _0: a, _1: b, _2: c};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$portTypeDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<*>'],
+		A2(
+			_elm_community$parser_combinators$Combine_ops['<$>'],
+			_Bogdanp$elm_ast$Ast_Statement$PortTypeDeclaration,
+			A2(
+				_elm_community$parser_combinators$Combine_ops['*>'],
+				_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
+				_Bogdanp$elm_ast$Ast_Helpers$loName)),
+		A2(
+			_elm_community$parser_combinators$Combine_ops['*>'],
+			_Bogdanp$elm_ast$Ast_Helpers$symbol(':'),
+			_Bogdanp$elm_ast$Ast_Statement$typeAnnotation)));
+var _Bogdanp$elm_ast$Ast_Statement$TypeDeclaration = F3(
+	function (a, b, c) {
+		return {ctor: 'TypeDeclaration', _0: a, _1: b, _2: c};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$typeDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<*>'],
+		A2(
+			_elm_community$parser_combinators$Combine_ops['<$>'],
+			_Bogdanp$elm_ast$Ast_Statement$TypeDeclaration,
+			A2(
+				_elm_community$parser_combinators$Combine_ops['*>'],
+				_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('type'),
+				_Bogdanp$elm_ast$Ast_Statement$type_)),
 		A2(
 			_elm_community$parser_combinators$Combine_ops['*>'],
 			A2(
 				_elm_community$parser_combinators$Combine_ops['*>'],
-				_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
-				_elm_community$parser_combinators$Combine$whitespace),
-			_Bogdanp$elm_ast$Ast_Expression$expression(ops)));
-};
-var _Bogdanp$elm_ast$Ast_Statement$FunctionTypeDeclaration = F2(
-	function (a, b) {
-		return {ctor: 'FunctionTypeDeclaration', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$functionTypeDeclaration = A2(
-	_elm_community$parser_combinators$Combine_ops['<*>'],
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<$>'],
-		_Bogdanp$elm_ast$Ast_Statement$FunctionTypeDeclaration,
-		A2(
-			_elm_community$parser_combinators$Combine_ops['<*'],
-			_elm_community$parser_combinators$Combine$choice(
-				{
-					ctor: '::',
-					_0: _Bogdanp$elm_ast$Ast_Helpers$loName,
-					_1: {
-						ctor: '::',
-						_0: _elm_community$parser_combinators$Combine$parens(_Bogdanp$elm_ast$Ast_Helpers$operator),
-						_1: {ctor: '[]'}
-					}
-				}),
-			_Bogdanp$elm_ast$Ast_Helpers$symbol(':'))),
-	_Bogdanp$elm_ast$Ast_Statement$typeAnnotation);
-var _Bogdanp$elm_ast$Ast_Statement$PortDeclaration = F3(
+				_elm_community$parser_combinators$Combine$whitespace,
+				_Bogdanp$elm_ast$Ast_Helpers$symbol('=')),
+			A2(
+				_elm_community$parser_combinators$Combine$sepBy1,
+				_Bogdanp$elm_ast$Ast_Helpers$symbol('|'),
+				A2(_Bogdanp$elm_ast$Ast_Helpers$between_, _elm_community$parser_combinators$Combine$whitespace, _Bogdanp$elm_ast$Ast_Statement$typeConstructor)))));
+var _Bogdanp$elm_ast$Ast_Statement$TypeAliasDeclaration = F3(
 	function (a, b, c) {
-		return {ctor: 'PortDeclaration', _0: a, _1: b, _2: c};
+		return {ctor: 'TypeAliasDeclaration', _0: a, _1: b, _2: c};
 	});
-var _Bogdanp$elm_ast$Ast_Statement$portDeclaration = function (ops) {
-	return A2(
+var _Bogdanp$elm_ast$Ast_Statement$typeAliasDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<*>'],
+		A2(
+			_elm_community$parser_combinators$Combine_ops['<$>'],
+			_Bogdanp$elm_ast$Ast_Statement$TypeAliasDeclaration,
+			A2(
+				_elm_community$parser_combinators$Combine_ops['*>'],
+				A2(
+					_elm_community$parser_combinators$Combine_ops['*>'],
+					_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('type'),
+					_Bogdanp$elm_ast$Ast_Helpers$symbol('alias')),
+				_Bogdanp$elm_ast$Ast_Statement$type_)),
+		A2(
+			_elm_community$parser_combinators$Combine_ops['*>'],
+			A2(
+				_elm_community$parser_combinators$Combine_ops['*>'],
+				_elm_community$parser_combinators$Combine$whitespace,
+				_Bogdanp$elm_ast$Ast_Helpers$symbol('=')),
+			_Bogdanp$elm_ast$Ast_Statement$typeAnnotation)));
+var _Bogdanp$elm_ast$Ast_Statement$ImportStatement = F4(
+	function (a, b, c, d) {
+		return {ctor: 'ImportStatement', _0: a, _1: b, _2: c, _3: d};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$importStatement = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	A2(
 		_elm_community$parser_combinators$Combine_ops['<*>'],
 		A2(
 			_elm_community$parser_combinators$Combine_ops['<*>'],
 			A2(
 				_elm_community$parser_combinators$Combine_ops['<$>'],
-				_Bogdanp$elm_ast$Ast_Statement$PortDeclaration,
+				_Bogdanp$elm_ast$Ast_Statement$ImportStatement,
 				A2(
 					_elm_community$parser_combinators$Combine_ops['*>'],
-					_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
-					_Bogdanp$elm_ast$Ast_Helpers$loName)),
-			_elm_community$parser_combinators$Combine$many(
-				A2(_Bogdanp$elm_ast$Ast_Helpers$between_, _Bogdanp$elm_ast$Ast_Helpers$spaces, _Bogdanp$elm_ast$Ast_Helpers$loName))),
-		A2(
-			_elm_community$parser_combinators$Combine_ops['*>'],
-			_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
-			_Bogdanp$elm_ast$Ast_Expression$expression(ops)));
-};
-var _Bogdanp$elm_ast$Ast_Statement$PortTypeDeclaration = F2(
-	function (a, b) {
-		return {ctor: 'PortTypeDeclaration', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$portTypeDeclaration = A2(
-	_elm_community$parser_combinators$Combine_ops['<*>'],
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<$>'],
-		_Bogdanp$elm_ast$Ast_Statement$PortTypeDeclaration,
-		A2(
-			_elm_community$parser_combinators$Combine_ops['*>'],
-			_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
-			_Bogdanp$elm_ast$Ast_Helpers$loName)),
-	A2(
-		_elm_community$parser_combinators$Combine_ops['*>'],
-		_Bogdanp$elm_ast$Ast_Helpers$symbol(':'),
-		_Bogdanp$elm_ast$Ast_Statement$typeAnnotation));
-var _Bogdanp$elm_ast$Ast_Statement$TypeDeclaration = F2(
-	function (a, b) {
-		return {ctor: 'TypeDeclaration', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$typeDeclaration = A2(
-	_elm_community$parser_combinators$Combine_ops['<*>'],
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<$>'],
-		_Bogdanp$elm_ast$Ast_Statement$TypeDeclaration,
-		A2(
-			_elm_community$parser_combinators$Combine_ops['*>'],
-			_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('type'),
-			_Bogdanp$elm_ast$Ast_Statement$type_)),
-	A2(
-		_elm_community$parser_combinators$Combine_ops['*>'],
-		A2(
-			_elm_community$parser_combinators$Combine_ops['*>'],
-			_elm_community$parser_combinators$Combine$whitespace,
-			_Bogdanp$elm_ast$Ast_Helpers$symbol('=')),
-		A2(
-			_elm_community$parser_combinators$Combine$sepBy1,
-			_Bogdanp$elm_ast$Ast_Helpers$symbol('|'),
-			A2(_Bogdanp$elm_ast$Ast_Helpers$between_, _elm_community$parser_combinators$Combine$whitespace, _Bogdanp$elm_ast$Ast_Statement$typeConstructor))));
-var _Bogdanp$elm_ast$Ast_Statement$TypeAliasDeclaration = F2(
-	function (a, b) {
-		return {ctor: 'TypeAliasDeclaration', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$typeAliasDeclaration = A2(
-	_elm_community$parser_combinators$Combine_ops['<*>'],
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<$>'],
-		_Bogdanp$elm_ast$Ast_Statement$TypeAliasDeclaration,
-		A2(
-			_elm_community$parser_combinators$Combine_ops['*>'],
-			A2(
-				_elm_community$parser_combinators$Combine_ops['*>'],
-				_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('type'),
-				_Bogdanp$elm_ast$Ast_Helpers$symbol('alias')),
-			_Bogdanp$elm_ast$Ast_Statement$type_)),
-	A2(
-		_elm_community$parser_combinators$Combine_ops['*>'],
-		A2(
-			_elm_community$parser_combinators$Combine_ops['*>'],
-			_elm_community$parser_combinators$Combine$whitespace,
-			_Bogdanp$elm_ast$Ast_Helpers$symbol('=')),
-		_Bogdanp$elm_ast$Ast_Statement$typeAnnotation));
-var _Bogdanp$elm_ast$Ast_Statement$ImportStatement = F3(
-	function (a, b, c) {
-		return {ctor: 'ImportStatement', _0: a, _1: b, _2: c};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$importStatement = A2(
-	_elm_community$parser_combinators$Combine_ops['<*>'],
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<*>'],
-		A2(
-			_elm_community$parser_combinators$Combine_ops['<$>'],
-			_Bogdanp$elm_ast$Ast_Statement$ImportStatement,
-			A2(
-				_elm_community$parser_combinators$Combine_ops['*>'],
-				_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('import'),
-				_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
+					_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('import'),
+					_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
+			_elm_community$parser_combinators$Combine$maybe(
+				A2(
+					_elm_community$parser_combinators$Combine_ops['*>'],
+					_Bogdanp$elm_ast$Ast_Helpers$symbol('as'),
+					_Bogdanp$elm_ast$Ast_Helpers$upName))),
 		_elm_community$parser_combinators$Combine$maybe(
 			A2(
 				_elm_community$parser_combinators$Combine_ops['*>'],
-				_Bogdanp$elm_ast$Ast_Helpers$symbol('as'),
-				_Bogdanp$elm_ast$Ast_Helpers$upName))),
-	_elm_community$parser_combinators$Combine$maybe(
+				_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
+				_Bogdanp$elm_ast$Ast_Statement$exports))));
+var _Bogdanp$elm_ast$Ast_Statement$EffectModuleDeclaration = F4(
+	function (a, b, c, d) {
+		return {ctor: 'EffectModuleDeclaration', _0: a, _1: b, _2: c, _3: d};
+	});
+var _Bogdanp$elm_ast$Ast_Statement$effectModuleDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
+	A2(
+		_elm_community$parser_combinators$Combine_ops['<*>'],
+		A2(
+			_elm_community$parser_combinators$Combine_ops['<*>'],
+			A2(
+				_elm_community$parser_combinators$Combine_ops['<$>'],
+				_Bogdanp$elm_ast$Ast_Statement$EffectModuleDeclaration,
+				A2(
+					_elm_community$parser_combinators$Combine_ops['*>'],
+					A2(
+						_elm_community$parser_combinators$Combine_ops['*>'],
+						_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('effect'),
+						_Bogdanp$elm_ast$Ast_Helpers$symbol('module')),
+					_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
+			A2(
+				_elm_community$parser_combinators$Combine_ops['*>'],
+				_Bogdanp$elm_ast$Ast_Helpers$symbol('where'),
+				_elm_community$parser_combinators$Combine$braces(
+					_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
+						A2(
+							_elm_community$parser_combinators$Combine_ops['<*>'],
+							A2(
+								_elm_community$parser_combinators$Combine_ops['<$>'],
+								F2(
+									function (v0, v1) {
+										return {ctor: '_Tuple2', _0: v0, _1: v1};
+									}),
+								_Bogdanp$elm_ast$Ast_Helpers$loName),
+							A2(
+								_elm_community$parser_combinators$Combine_ops['*>'],
+								_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
+								_Bogdanp$elm_ast$Ast_Helpers$upName)))))),
 		A2(
 			_elm_community$parser_combinators$Combine_ops['*>'],
 			_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
 			_Bogdanp$elm_ast$Ast_Statement$exports)));
-var _Bogdanp$elm_ast$Ast_Statement$EffectModuleDeclaration = F3(
+var _Bogdanp$elm_ast$Ast_Statement$PortModuleDeclaration = F3(
 	function (a, b, c) {
-		return {ctor: 'EffectModuleDeclaration', _0: a, _1: b, _2: c};
+		return {ctor: 'PortModuleDeclaration', _0: a, _1: b, _2: c};
 	});
-var _Bogdanp$elm_ast$Ast_Statement$effectModuleDeclaration = A2(
-	_elm_community$parser_combinators$Combine_ops['<*>'],
+var _Bogdanp$elm_ast$Ast_Statement$portModuleDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 	A2(
 		_elm_community$parser_combinators$Combine_ops['<*>'],
 		A2(
 			_elm_community$parser_combinators$Combine_ops['<$>'],
-			_Bogdanp$elm_ast$Ast_Statement$EffectModuleDeclaration,
+			_Bogdanp$elm_ast$Ast_Statement$PortModuleDeclaration,
 			A2(
 				_elm_community$parser_combinators$Combine_ops['*>'],
 				A2(
 					_elm_community$parser_combinators$Combine_ops['*>'],
-					_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('effect'),
+					_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
 					_Bogdanp$elm_ast$Ast_Helpers$symbol('module')),
 				_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
 		A2(
 			_elm_community$parser_combinators$Combine_ops['*>'],
-			_Bogdanp$elm_ast$Ast_Helpers$symbol('where'),
-			_elm_community$parser_combinators$Combine$braces(
-				_Bogdanp$elm_ast$Ast_Helpers$commaSeparated(
-					A2(
-						_elm_community$parser_combinators$Combine_ops['<*>'],
-						A2(
-							_elm_community$parser_combinators$Combine_ops['<$>'],
-							F2(
-								function (v0, v1) {
-									return {ctor: '_Tuple2', _0: v0, _1: v1};
-								}),
-							_Bogdanp$elm_ast$Ast_Helpers$loName),
-						A2(
-							_elm_community$parser_combinators$Combine_ops['*>'],
-							_Bogdanp$elm_ast$Ast_Helpers$symbol('='),
-							_Bogdanp$elm_ast$Ast_Helpers$upName)))))),
-	A2(
-		_elm_community$parser_combinators$Combine_ops['*>'],
-		_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
-		_Bogdanp$elm_ast$Ast_Statement$exports));
-var _Bogdanp$elm_ast$Ast_Statement$PortModuleDeclaration = F2(
-	function (a, b) {
-		return {ctor: 'PortModuleDeclaration', _0: a, _1: b};
+			_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
+			_Bogdanp$elm_ast$Ast_Statement$exports)));
+var _Bogdanp$elm_ast$Ast_Statement$ModuleDeclaration = F3(
+	function (a, b, c) {
+		return {ctor: 'ModuleDeclaration', _0: a, _1: b, _2: c};
 	});
-var _Bogdanp$elm_ast$Ast_Statement$portModuleDeclaration = A2(
-	_elm_community$parser_combinators$Combine_ops['<*>'],
+var _Bogdanp$elm_ast$Ast_Statement$moduleDeclaration = _Bogdanp$elm_ast$Ast_Helpers$withMeta(
 	A2(
-		_elm_community$parser_combinators$Combine_ops['<$>'],
-		_Bogdanp$elm_ast$Ast_Statement$PortModuleDeclaration,
+		_elm_community$parser_combinators$Combine_ops['<*>'],
 		A2(
-			_elm_community$parser_combinators$Combine_ops['*>'],
+			_elm_community$parser_combinators$Combine_ops['<$>'],
+			_Bogdanp$elm_ast$Ast_Statement$ModuleDeclaration,
 			A2(
 				_elm_community$parser_combinators$Combine_ops['*>'],
-				_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('port'),
-				_Bogdanp$elm_ast$Ast_Helpers$symbol('module')),
-			_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
-	A2(
-		_elm_community$parser_combinators$Combine_ops['*>'],
-		_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
-		_Bogdanp$elm_ast$Ast_Statement$exports));
-var _Bogdanp$elm_ast$Ast_Statement$ModuleDeclaration = F2(
-	function (a, b) {
-		return {ctor: 'ModuleDeclaration', _0: a, _1: b};
-	});
-var _Bogdanp$elm_ast$Ast_Statement$moduleDeclaration = A2(
-	_elm_community$parser_combinators$Combine_ops['<*>'],
-	A2(
-		_elm_community$parser_combinators$Combine_ops['<$>'],
-		_Bogdanp$elm_ast$Ast_Statement$ModuleDeclaration,
+				_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('module'),
+				_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
 		A2(
 			_elm_community$parser_combinators$Combine_ops['*>'],
-			_Bogdanp$elm_ast$Ast_Helpers$initialSymbol('module'),
-			_Bogdanp$elm_ast$Ast_Helpers$moduleName)),
-	A2(
-		_elm_community$parser_combinators$Combine_ops['*>'],
-		_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
-		_Bogdanp$elm_ast$Ast_Statement$exports));
+			_Bogdanp$elm_ast$Ast_Helpers$symbol('exposing'),
+			_Bogdanp$elm_ast$Ast_Statement$exports)));
 var _Bogdanp$elm_ast$Ast_Statement$statement = function (ops) {
-	return _elm_community$parser_combinators$Combine$choice(
-		{
-			ctor: '::',
-			_0: _Bogdanp$elm_ast$Ast_Statement$portModuleDeclaration,
-			_1: {
-				ctor: '::',
-				_0: _Bogdanp$elm_ast$Ast_Statement$effectModuleDeclaration,
-				_1: {
+	return _elm_community$parser_combinators$Combine$lazy(
+		function (_p21) {
+			var _p22 = _p21;
+			return _elm_community$parser_combinators$Combine$choice(
+				{
 					ctor: '::',
-					_0: _Bogdanp$elm_ast$Ast_Statement$moduleDeclaration,
+					_0: _Bogdanp$elm_ast$Ast_Statement$portModuleDeclaration,
 					_1: {
 						ctor: '::',
-						_0: _Bogdanp$elm_ast$Ast_Statement$importStatement,
+						_0: _Bogdanp$elm_ast$Ast_Statement$effectModuleDeclaration,
 						_1: {
 							ctor: '::',
-							_0: _Bogdanp$elm_ast$Ast_Statement$typeAliasDeclaration,
+							_0: _Bogdanp$elm_ast$Ast_Statement$moduleDeclaration,
 							_1: {
 								ctor: '::',
-								_0: _Bogdanp$elm_ast$Ast_Statement$typeDeclaration,
+								_0: _Bogdanp$elm_ast$Ast_Statement$importStatement,
 								_1: {
 									ctor: '::',
-									_0: _Bogdanp$elm_ast$Ast_Statement$portTypeDeclaration,
+									_0: _Bogdanp$elm_ast$Ast_Statement$typeAliasDeclaration,
 									_1: {
 										ctor: '::',
-										_0: _Bogdanp$elm_ast$Ast_Statement$portDeclaration(ops),
+										_0: _Bogdanp$elm_ast$Ast_Statement$typeDeclaration,
 										_1: {
 											ctor: '::',
-											_0: _Bogdanp$elm_ast$Ast_Statement$functionTypeDeclaration,
+											_0: _Bogdanp$elm_ast$Ast_Statement$portTypeDeclaration,
 											_1: {
 												ctor: '::',
-												_0: _Bogdanp$elm_ast$Ast_Statement$functionDeclaration(ops),
+												_0: _Bogdanp$elm_ast$Ast_Statement$portDeclaration(ops),
 												_1: {
 													ctor: '::',
-													_0: _Bogdanp$elm_ast$Ast_Statement$infixDeclaration,
+													_0: _Bogdanp$elm_ast$Ast_Statement$functionTypeDeclaration,
 													_1: {
 														ctor: '::',
-														_0: _Bogdanp$elm_ast$Ast_Statement$comment,
-														_1: {ctor: '[]'}
+														_0: _Bogdanp$elm_ast$Ast_Statement$functionDeclaration(ops),
+														_1: {
+															ctor: '::',
+															_0: _Bogdanp$elm_ast$Ast_Statement$infixDeclaration,
+															_1: {
+																ctor: '::',
+																_0: _Bogdanp$elm_ast$Ast_Statement$comment,
+																_1: {ctor: '[]'}
+															}
+														}
 													}
 												}
 											}
@@ -8828,8 +8888,7 @@ var _Bogdanp$elm_ast$Ast_Statement$statement = function (ops) {
 							}
 						}
 					}
-				}
-			}
+				});
 		});
 };
 var _Bogdanp$elm_ast$Ast_Statement$statements = function (ops) {
@@ -12701,6 +12760,10 @@ var _elm_lang$html$Html_Events$Options = F2(
 		return {stopPropagation: a, preventDefault: b};
 	});
 
+var _Bogdanp$elm_ast$Main$toText = function (_p0) {
+	return _elm_lang$html$Html$text(
+		_elm_lang$core$Basics$toString(_p0));
+};
 var _Bogdanp$elm_ast$Main$withChild = F2(
 	function (title, children) {
 		return A2(
@@ -12713,8 +12776,7 @@ var _Bogdanp$elm_ast$Main$withChild = F2(
 					{ctor: '[]'},
 					{
 						ctor: '::',
-						_0: _elm_lang$html$Html$text(
-							_elm_lang$core$Basics$toString(title)),
+						_0: _Bogdanp$elm_ast$Main$toText(title),
 						_1: {ctor: '[]'}
 					}),
 				_1: {
@@ -12728,23 +12790,23 @@ var _Bogdanp$elm_ast$Main$withChild = F2(
 			});
 	});
 var _Bogdanp$elm_ast$Main$expression = function (e) {
-	var _p0 = e;
-	switch (_p0.ctor) {
+	var _p1 = e;
+	switch (_p1.ctor) {
 		case 'List':
 			return A2(
 				_Bogdanp$elm_ast$Main$withChild,
 				e,
-				A2(_elm_lang$core$List$map, _Bogdanp$elm_ast$Main$expression, _p0._0));
+				A2(_elm_lang$core$List$map, _Bogdanp$elm_ast$Main$expression, _p1._0));
 		case 'Application':
 			return A2(
 				_Bogdanp$elm_ast$Main$withChild,
 				e,
 				{
 					ctor: '::',
-					_0: _Bogdanp$elm_ast$Main$expression(_p0._0),
+					_0: _Bogdanp$elm_ast$Main$expression(_p1._0),
 					_1: {
 						ctor: '::',
-						_0: _Bogdanp$elm_ast$Main$expression(_p0._1),
+						_0: _Bogdanp$elm_ast$Main$expression(_p1._1),
 						_1: {ctor: '[]'}
 					}
 				});
@@ -12759,8 +12821,7 @@ var _Bogdanp$elm_ast$Main$expression = function (e) {
 						{ctor: '[]'},
 						{
 							ctor: '::',
-							_0: _elm_lang$html$Html$text(
-								_elm_lang$core$Basics$toString(_p0)),
+							_0: _Bogdanp$elm_ast$Main$toText(_p1),
 							_1: {ctor: '[]'}
 						}),
 					_1: {ctor: '[]'}
@@ -12768,14 +12829,14 @@ var _Bogdanp$elm_ast$Main$expression = function (e) {
 	}
 };
 var _Bogdanp$elm_ast$Main$statement = function (s) {
-	var _p1 = s;
-	if (_p1.ctor === 'FunctionDeclaration') {
+	var _p2 = s;
+	if (_p2.ctor === 'FunctionDeclaration') {
 		return A2(
 			_Bogdanp$elm_ast$Main$withChild,
 			s,
 			{
 				ctor: '::',
-				_0: _Bogdanp$elm_ast$Main$expression(_p1._2),
+				_0: _Bogdanp$elm_ast$Main$expression(_p2._2),
 				_1: {ctor: '[]'}
 			});
 	} else {
@@ -12789,8 +12850,7 @@ var _Bogdanp$elm_ast$Main$statement = function (s) {
 					{ctor: '[]'},
 					{
 						ctor: '::',
-						_0: _elm_lang$html$Html$text(
-							_elm_lang$core$Basics$toString(_p1)),
+						_0: _Bogdanp$elm_ast$Main$toText(_p2),
 						_1: {ctor: '[]'}
 					}),
 				_1: {ctor: '[]'}
@@ -12798,28 +12858,27 @@ var _Bogdanp$elm_ast$Main$statement = function (s) {
 	}
 };
 var _Bogdanp$elm_ast$Main$tree = function (m) {
-	var _p2 = _Bogdanp$elm_ast$Ast$parse(m);
-	if ((_p2.ctor === 'Ok') && (_p2._0.ctor === '_Tuple3')) {
+	var _p3 = _Bogdanp$elm_ast$Ast$parse(m);
+	if ((_p3.ctor === 'Ok') && (_p3._0.ctor === '_Tuple3')) {
 		return A2(
 			_elm_lang$html$Html$ul,
 			{ctor: '[]'},
-			A2(_elm_lang$core$List$map, _Bogdanp$elm_ast$Main$statement, _p2._0._2));
+			A2(_elm_lang$core$List$map, _Bogdanp$elm_ast$Main$statement, _p3._0._2));
 	} else {
 		return A2(
 			_elm_lang$html$Html$div,
 			{ctor: '[]'},
 			{
 				ctor: '::',
-				_0: _elm_lang$html$Html$text(
-					_elm_lang$core$Basics$toString(_p2)),
+				_0: _Bogdanp$elm_ast$Main$toText(_p3),
 				_1: {ctor: '[]'}
 			});
 	}
 };
 var _Bogdanp$elm_ast$Main$update = F2(
 	function (action, model) {
-		var _p3 = action;
-		return _p3._0;
+		var _p4 = action;
+		return _p4._0;
 	});
 var _Bogdanp$elm_ast$Main$init = 'module Main exposing (..)\n\nf : Int -> Int\nf x = x + 1\n\ng : Int -> Int\ng x = x * 2\n\nh = f << g\n';
 var _Bogdanp$elm_ast$Main$Replace = function (a) {

--- a/src/Ast/Expression.elm
+++ b/src/Ast/Expression.elm
@@ -323,7 +323,8 @@ operatorOrAsBetween : Parser s Operator
 operatorOrAsBetween =
     lazy <|
         \() ->
-            between_ whitespace <| operator <|> withMeta ((,) <$> symbol_ "as")
+            between_ whitespace <|
+                choice [ operator, withMeta ((,) <$> symbol_ "as") ]
 
 
 binary : OpTable -> Parser s Expression
@@ -334,16 +335,17 @@ binary ops =
                 next =
                     operatorOrAsBetween
                         >>= \op ->
-                                lazy <|
-                                    \() ->
-                                        (or (Cont <$> application ops) (Stop <$> expression ops))
-                                            >>= \e ->
-                                                    case e of
-                                                        Cont t ->
-                                                            ((::) ( op, t )) <$> collect
+                                (or
+                                    (Cont <$> application ops)
+                                    (Stop <$> expression ops)
+                                )
+                                    >>= \e ->
+                                            case e of
+                                                Cont t ->
+                                                    ((::) ( op, t )) <$> collect
 
-                                                        Stop ex ->
-                                                            succeed [ ( op, ex ) ]
+                                                Stop ex ->
+                                                    succeed [ ( op, ex ) ]
 
                 collect =
                     lazy <| \() -> choice [ next, succeed [] ]

--- a/src/Ast/Expression.elm
+++ b/src/Ast/Expression.elm
@@ -146,6 +146,7 @@ variable =
             <$> choice
                     [ singleton <$> loName
                     , sepBy1 (Combine.string ".") upName
+                    , singleton <$> parens operatorAsString
                     , singleton <$> parens (Combine.regex ",+")
                     , singleton <$> emptyTuple
                     ]

--- a/src/Ast/Helpers.elm
+++ b/src/Ast/Helpers.elm
@@ -32,12 +32,11 @@ type alias Meta =
 makeMeta : ParseLocation -> Meta
 makeMeta { line, column } =
     { line = line
-    , column = column
-
-    -- if column < 0 then
-    --     0
-    -- else
-    --     column
+    , column =
+        if column < 0 then
+            0
+        else
+            column
     }
 
 

--- a/src/Ast/Helpers.elm
+++ b/src/Ast/Helpers.elm
@@ -28,6 +28,7 @@ type alias Meta =
     , column : Int
     }
 
+type alias Operator = (String, Meta)
 
 makeMeta : ParseLocation -> Meta
 makeMeta { line, column } =
@@ -139,8 +140,7 @@ emptyTuple : Parser s String
 emptyTuple =
     string "()"
 
-
-operator : Parser s String
+operator : Parser s Operator
 operator =
     lazy <|
         \() ->
@@ -149,7 +149,7 @@ operator =
                         if List.member n reservedOperators then
                             fail <| "operator '" ++ n ++ "' is reserved"
                         else
-                            succeed n
+                            withLocation (\l -> succeed (n,makeMeta l))
                     )
 
 

--- a/src/Ast/Helpers.elm
+++ b/src/Ast/Helpers.elm
@@ -28,7 +28,10 @@ type alias Meta =
     , column : Int
     }
 
-type alias Operator = (String, Meta)
+
+type alias Operator =
+    ( String, Meta )
+
 
 makeMeta : ParseLocation -> Meta
 makeMeta { line, column } =
@@ -140,6 +143,7 @@ emptyTuple : Parser s String
 emptyTuple =
     string "()"
 
+
 operator : Parser s Operator
 operator =
     lazy <|
@@ -149,7 +153,7 @@ operator =
                         if List.member n reservedOperators then
                             fail <| "operator '" ++ n ++ "' is reserved"
                         else
-                            withLocation (\l -> succeed (n,makeMeta l))
+                            withLocation (\l -> succeed ( n, makeMeta l ))
                     )
 
 

--- a/src/Ast/Helpers.elm
+++ b/src/Ast/Helpers.elm
@@ -144,6 +144,19 @@ emptyTuple =
     string "()"
 
 
+operatorAsString : Parser s String
+operatorAsString =
+    lazy <|
+        \() ->
+            regex "[+\\-\\/*=.$<>:&|^?%#@~!]+|\x8As\x08"
+                >>= (\n ->
+                        if List.member n reservedOperators then
+                            fail <| "operator '" ++ n ++ "' is reserved"
+                        else
+                            succeed n
+                    )
+
+
 operator : Parser s Operator
 operator =
     lazy <|

--- a/src/Ast/Helpers.elm
+++ b/src/Ast/Helpers.elm
@@ -21,6 +21,31 @@ type alias Alias =
     String
 
 
+{-| Representation of Parser meta information
+-}
+type alias Meta =
+    { line : Int
+    , column : Int
+    }
+
+
+makeMeta : ParseLocation -> Meta
+makeMeta { line, column } =
+    { line = line
+    , column = column
+
+    -- if column < 0 then
+    --     0
+    -- else
+    --     column
+    }
+
+
+withMeta : Parser s (Meta -> b) -> Parser s b
+withMeta p =
+    withLocation (flip andMap p << succeed << makeMeta)
+
+
 reserved : List Name
 reserved =
     [ "module"

--- a/src/Ast/Statement.elm
+++ b/src/Ast/Statement.elm
@@ -109,7 +109,7 @@ typeExport =
 subsetExport : Parser s ExportSet
 subsetExport =
     SubsetExport
-        <$> commaSeparated (functionExport |> or typeExport)
+        <$> commaSeparated (typeExport <|> functionExport)
 
 
 exports : Parser s ExportSet

--- a/src/Ast/Statement.elm
+++ b/src/Ast/Statement.elm
@@ -83,7 +83,7 @@ allExport =
 
 functionExport : Parser s ExportSet
 functionExport =
-    FunctionExport <$> choice [ functionName, parens operator ]
+    FunctionExport <$> choice [ functionName, map (Tuple.first) (parens operator) ]
 
 
 constructorSubsetExports : Parser s ExportSet
@@ -319,7 +319,7 @@ functionTypeDeclaration : Parser s Statement
 functionTypeDeclaration =
     withMeta <|
         FunctionTypeDeclaration
-            <$> (choice [ loName, parens operator ] <* symbol ":")
+            <$> (choice [ loName, map (Tuple.first) (parens operator) ] <* symbol ":")
             <*> typeAnnotation
 
 
@@ -327,7 +327,7 @@ functionDeclaration : OpTable -> Parser s Statement
 functionDeclaration ops =
     withMeta <|
         FunctionDeclaration
-            <$> (choice [ loName, parens operator ])
+            <$> (choice [ loName, map (Tuple.first) (parens operator) ])
             <*> (many (between_ whitespace <| term ops))
             <*> (symbol "=" *> whitespace *> expression ops)
 
@@ -347,7 +347,7 @@ infixDeclaration =
                     , N <$ initialSymbol "infix"
                     ]
             <*> (spaces *> Combine.Num.int)
-            <*> (spaces *> (loName <|> operator))
+            <*> (spaces *> (loName <|> map (Tuple.first) operator))
 
 
 

--- a/src/Ast/Statement.elm
+++ b/src/Ast/Statement.elm
@@ -50,8 +50,7 @@ type Type
     | TypeRecordConstructor Type (List ( Name, Type )) Meta
     | TypeRecord (List ( Name, Type )) Meta
     | TypeTuple (List Type) Meta
-      -- missing meta
-    | TypeApplication Type Type
+    | TypeApplication Type Type Meta
 
 
 {-| Representations for Elm's statements.
@@ -134,7 +133,11 @@ typeConstant =
 
 typeApplication : Parser s (Type -> Type -> Type)
 typeApplication =
-    TypeApplication <$ symbol "->"
+    let
+        flippedApp m e1 e2 =
+            TypeApplication e1 e2 m
+    in
+        withMeta ((\m -> flippedApp m) <$ symbol "->")
 
 
 typeTuple : Parser s Type

--- a/src/Ast/Statement.elm
+++ b/src/Ast/Statement.elm
@@ -92,12 +92,7 @@ constructorSubsetExports =
 
 constructorExports : Parser s (Maybe ExportSet)
 constructorExports =
-    maybe <|
-        parens <|
-            choice
-                [ allExport
-                , constructorSubsetExports
-                ]
+    maybe <| parens <| choice [ allExport, constructorSubsetExports ]
 
 
 typeExport : Parser s ExportSet
@@ -107,8 +102,7 @@ typeExport =
 
 subsetExport : Parser s ExportSet
 subsetExport =
-    SubsetExport
-        <$> commaSeparated (typeExport <|> functionExport)
+    SubsetExport <$> commaSeparated (typeExport <|> functionExport)
 
 
 exports : Parser s ExportSet
@@ -123,9 +117,7 @@ exports =
 
 typeVariable : Parser s Type
 typeVariable =
-    withMeta <|
-        TypeVariable
-            <$> regex "[a-z]+(\\w|_)*"
+    withMeta <| TypeVariable <$> regex "[a-z]+(\\w|_)*"
 
 
 typeConstant : Parser s Type
@@ -149,18 +141,14 @@ typeTuple : Parser s Type
 typeTuple =
     lazy <|
         \() ->
-            withMeta <|
-                TypeTuple
-                    <$> parens (commaSeparated_ type_)
+            withMeta <| TypeTuple <$> parens (commaSeparated_ type_)
 
 
 typeRecordPair : Parser s ( Name, Type )
 typeRecordPair =
     lazy <|
         \() ->
-            (,)
-                <$> (loName <* symbol ":")
-                <*> typeAnnotation
+            (,) <$> (loName <* symbol ":") <*> typeAnnotation
 
 
 typeRecordPairs : Parser s (List ( Name, Type ))
@@ -185,10 +173,7 @@ typeRecord : Parser s Type
 typeRecord =
     lazy <|
         \() ->
-            braces <|
-                withMeta <|
-                    TypeRecord
-                        <$> typeRecordPairs
+            braces <| withMeta <| TypeRecord <$> typeRecordPairs
 
 
 typeParameter : Parser s Type
@@ -369,16 +354,12 @@ infixDeclaration =
 
 singleLineComment : Parser s Statement
 singleLineComment =
-    withMeta <|
-        Comment
-            <$> (string "--" *> regex ".*" <* whitespace)
+    withMeta <| Comment <$> (string "--" *> regex ".*" <* whitespace)
 
 
 multiLineComment : Parser s Statement
 multiLineComment =
-    withMeta <|
-        (Comment << String.fromList)
-            <$> (string "{-" *> manyTill anyChar (string "-}"))
+    withMeta <| (Comment << String.fromList) <$> (string "{-" *> manyTill anyChar (string "-}"))
 
 
 comment : Parser s Statement
@@ -422,18 +403,9 @@ infixStatements : Parser s (List Statement)
 infixStatements =
     let
         statements =
-            many
-                (choice
-                    [ Just <$> infixDeclaration
-                    , Nothing <$ regex ".*"
-                    ]
-                    <* whitespace
-                )
-                <* end
+            many (choice [ Just <$> infixDeclaration, Nothing <$ regex ".*" ] <* whitespace) <* end
     in
-        statements
-            >>= \xs ->
-                    succeed <| List.filterMap identity xs
+        statements >>= \xs -> succeed <| List.filterMap identity xs
 
 
 {-| A scanner that returns an updated OpTable based on the infix
@@ -450,6 +422,4 @@ opTable ops =
                 _ ->
                     Debug.crash "impossible"
     in
-        infixStatements
-            >>= \xs ->
-                    succeed <| List.foldr collect ops xs
+        infixStatements >>= \xs -> succeed <| List.foldr collect ops xs

--- a/src/Ast/Statement.elm
+++ b/src/Ast/Statement.elm
@@ -45,29 +45,30 @@ type ExportSet
 {-| Representations for Elm's type syntax.
 -}
 type Type
-    = TypeConstructor QualifiedType (List Type)
-    | TypeVariable Name
-    | TypeRecordConstructor Type (List ( Name, Type ))
-    | TypeRecord (List ( Name, Type ))
-    | TypeTuple (List Type)
+    = TypeConstructor QualifiedType (List Type) Meta
+    | TypeVariable Name Meta
+    | TypeRecordConstructor Type (List ( Name, Type )) Meta
+    | TypeRecord (List ( Name, Type )) Meta
+    | TypeTuple (List Type) Meta
+      -- missing meta
     | TypeApplication Type Type
 
 
 {-| Representations for Elm's statements.
 -}
 type Statement
-    = ModuleDeclaration ModuleName ExportSet
-    | PortModuleDeclaration ModuleName ExportSet
-    | EffectModuleDeclaration ModuleName (List ( Name, Name )) ExportSet
-    | ImportStatement ModuleName (Maybe Alias) (Maybe ExportSet)
-    | TypeAliasDeclaration Type Type
-    | TypeDeclaration Type (List Type)
-    | PortTypeDeclaration Name Type
-    | PortDeclaration Name (List Name) Expression
-    | FunctionTypeDeclaration Name Type
-    | FunctionDeclaration Name (List Expression) Expression
-    | InfixDeclaration Assoc Int Name
-    | Comment String
+    = ModuleDeclaration ModuleName ExportSet Meta
+    | PortModuleDeclaration ModuleName ExportSet Meta
+    | EffectModuleDeclaration ModuleName (List ( Name, Name )) ExportSet Meta
+    | ImportStatement ModuleName (Maybe Alias) (Maybe ExportSet) Meta
+    | TypeAliasDeclaration Type Type Meta
+    | TypeDeclaration Type (List Type) Meta
+    | PortTypeDeclaration Name Type Meta
+    | PortDeclaration Name (List Name) Expression Meta
+    | FunctionTypeDeclaration Name Type Meta
+    | FunctionDeclaration Name (List Expression) Expression Meta
+    | InfixDeclaration Assoc Int Name Meta
+    | Comment String Meta
 
 
 
@@ -123,12 +124,12 @@ exports =
 
 typeVariable : Parser s Type
 typeVariable =
-    TypeVariable <$> regex "[a-z]+(\\w|_)*"
+    withMeta <| TypeVariable <$> regex "[a-z]+(\\w|_)*"
 
 
 typeConstant : Parser s Type
 typeConstant =
-    TypeConstructor <$> sepBy1 (string ".") upName <*> succeed []
+    withMeta <| TypeConstructor <$> sepBy1 (string ".") upName <*> succeed []
 
 
 typeApplication : Parser s (Type -> Type -> Type)
@@ -140,7 +141,7 @@ typeTuple : Parser s Type
 typeTuple =
     lazy <|
         \() ->
-            TypeTuple <$> parens (commaSeparated_ type_)
+            withMeta <| TypeTuple <$> parens (commaSeparated_ type_)
 
 
 typeRecordPair : Parser s ( Name, Type )
@@ -162,9 +163,10 @@ typeRecordConstructor =
     lazy <|
         \() ->
             braces <|
-                TypeRecordConstructor
-                    <$> (between_ spaces typeVariable)
-                    <*> (symbol "|" *> typeRecordPairs)
+                withMeta <|
+                    TypeRecordConstructor
+                        <$> (between_ spaces typeVariable)
+                        <*> (symbol "|" *> typeRecordPairs)
 
 
 typeRecord : Parser s Type
@@ -172,8 +174,9 @@ typeRecord =
     lazy <|
         \() ->
             braces <|
-                TypeRecord
-                    <$> typeRecordPairs
+                withMeta <|
+                    TypeRecord
+                        <$> typeRecordPairs
 
 
 typeParameter : Parser s Type
@@ -195,7 +198,7 @@ typeConstructor : Parser s Type
 typeConstructor =
     lazy <|
         \() ->
-            TypeConstructor <$> sepBy1 (string ".") upName <*> many typeParameter
+            withMeta <| TypeConstructor <$> sepBy1 (string ".") upName <*> many typeParameter
 
 
 type_ : Parser s Type
@@ -227,24 +230,27 @@ typeAnnotation =
 
 portModuleDeclaration : Parser s Statement
 portModuleDeclaration =
-    PortModuleDeclaration
-        <$> (initialSymbol "port" *> symbol "module" *> moduleName)
-        <*> (symbol "exposing" *> exports)
+    withMeta <|
+        PortModuleDeclaration
+            <$> (initialSymbol "port" *> symbol "module" *> moduleName)
+            <*> (symbol "exposing" *> exports)
 
 
 effectModuleDeclaration : Parser s Statement
 effectModuleDeclaration =
-    EffectModuleDeclaration
-        <$> (initialSymbol "effect" *> symbol "module" *> moduleName)
-        <*> (symbol "where" *> braces (commaSeparated ((,) <$> loName <*> (symbol "=" *> upName))))
-        <*> (symbol "exposing" *> exports)
+    withMeta <|
+        EffectModuleDeclaration
+            <$> (initialSymbol "effect" *> symbol "module" *> moduleName)
+            <*> (symbol "where" *> braces (commaSeparated ((,) <$> loName <*> (symbol "=" *> upName))))
+            <*> (symbol "exposing" *> exports)
 
 
 moduleDeclaration : Parser s Statement
 moduleDeclaration =
-    ModuleDeclaration
-        <$> (initialSymbol "module" *> moduleName)
-        <*> (symbol "exposing" *> exports)
+    withMeta <|
+        ModuleDeclaration
+            <$> (initialSymbol "module" *> moduleName)
+            <*> (symbol "exposing" *> exports)
 
 
 
@@ -254,10 +260,11 @@ moduleDeclaration =
 
 importStatement : Parser s Statement
 importStatement =
-    ImportStatement
-        <$> (initialSymbol "import" *> moduleName)
-        <*> maybe (symbol "as" *> upName)
-        <*> maybe (symbol "exposing" *> exports)
+    withMeta <|
+        ImportStatement
+            <$> (initialSymbol "import" *> moduleName)
+            <*> maybe (symbol "as" *> upName)
+            <*> maybe (symbol "exposing" *> exports)
 
 
 
@@ -267,16 +274,18 @@ importStatement =
 
 typeAliasDeclaration : Parser s Statement
 typeAliasDeclaration =
-    TypeAliasDeclaration
-        <$> (initialSymbol "type" *> symbol "alias" *> type_)
-        <*> (whitespace *> symbol "=" *> typeAnnotation)
+    withMeta <|
+        TypeAliasDeclaration
+            <$> (initialSymbol "type" *> symbol "alias" *> type_)
+            <*> (whitespace *> symbol "=" *> typeAnnotation)
 
 
 typeDeclaration : Parser s Statement
 typeDeclaration =
-    TypeDeclaration
-        <$> (initialSymbol "type" *> type_)
-        <*> (whitespace *> symbol "=" *> (sepBy1 (symbol "|") (between_ whitespace typeConstructor)))
+    withMeta <|
+        TypeDeclaration
+            <$> (initialSymbol "type" *> type_)
+            <*> (whitespace *> symbol "=" *> (sepBy1 (symbol "|") (between_ whitespace typeConstructor)))
 
 
 
@@ -286,17 +295,19 @@ typeDeclaration =
 
 portTypeDeclaration : Parser s Statement
 portTypeDeclaration =
-    PortTypeDeclaration
-        <$> (initialSymbol "port" *> loName)
-        <*> (symbol ":" *> typeAnnotation)
+    withMeta <|
+        PortTypeDeclaration
+            <$> (initialSymbol "port" *> loName)
+            <*> (symbol ":" *> typeAnnotation)
 
 
 portDeclaration : OpTable -> Parser s Statement
 portDeclaration ops =
-    PortDeclaration
-        <$> (initialSymbol "port" *> loName)
-        <*> (many <| between_ spaces loName)
-        <*> (symbol "=" *> expression ops)
+    withMeta <|
+        PortDeclaration
+            <$> (initialSymbol "port" *> loName)
+            <*> (many <| between_ spaces loName)
+            <*> (symbol "=" *> expression ops)
 
 
 
@@ -306,15 +317,19 @@ portDeclaration ops =
 
 functionTypeDeclaration : Parser s Statement
 functionTypeDeclaration =
-    FunctionTypeDeclaration <$> (choice [ loName, parens operator ] <* symbol ":") <*> typeAnnotation
+    withMeta <|
+        FunctionTypeDeclaration
+            <$> (choice [ loName, parens operator ] <* symbol ":")
+            <*> typeAnnotation
 
 
 functionDeclaration : OpTable -> Parser s Statement
 functionDeclaration ops =
-    FunctionDeclaration
-        <$> (choice [ loName, parens operator ])
-        <*> (many (between_ whitespace <| term ops))
-        <*> (symbol "=" *> whitespace *> expression ops)
+    withMeta <|
+        FunctionDeclaration
+            <$> (choice [ loName, parens operator ])
+            <*> (many (between_ whitespace <| term ops))
+            <*> (symbol "=" *> whitespace *> expression ops)
 
 
 
@@ -324,14 +339,15 @@ functionDeclaration ops =
 
 infixDeclaration : Parser s Statement
 infixDeclaration =
-    InfixDeclaration
-        <$> choice
-                [ L <$ initialSymbol "infixl"
-                , R <$ initialSymbol "infixr"
-                , N <$ initialSymbol "infix"
-                ]
-        <*> (spaces *> Combine.Num.int)
-        <*> (spaces *> (loName <|> operator))
+    withMeta <|
+        InfixDeclaration
+            <$> choice
+                    [ L <$ initialSymbol "infixl"
+                    , R <$ initialSymbol "infixr"
+                    , N <$ initialSymbol "infix"
+                    ]
+            <*> (spaces *> Combine.Num.int)
+            <*> (spaces *> (loName <|> operator))
 
 
 
@@ -341,12 +357,12 @@ infixDeclaration =
 
 singleLineComment : Parser s Statement
 singleLineComment =
-    Comment <$> (string "--" *> regex ".*" <* whitespace)
+    withMeta <| Comment <$> (string "--" *> regex ".*" <* whitespace)
 
 
 multiLineComment : Parser s Statement
 multiLineComment =
-    (Comment << String.fromList) <$> (string "{-" *> manyTill anyChar (string "-}"))
+    withMeta <| (Comment << String.fromList) <$> (string "{-" *> manyTill anyChar (string "-}"))
 
 
 comment : Parser s Statement
@@ -412,7 +428,7 @@ opTable ops =
     let
         collect s d =
             case s of
-                InfixDeclaration a l n ->
+                InfixDeclaration a l n _ ->
                     Dict.insert n ( a, l ) d
 
                 _ ->

--- a/src/Ast/Statement.elm
+++ b/src/Ast/Statement.elm
@@ -123,12 +123,17 @@ exports =
 
 typeVariable : Parser s Type
 typeVariable =
-    withMeta <| TypeVariable <$> regex "[a-z]+(\\w|_)*"
+    withMeta <|
+        TypeVariable
+            <$> regex "[a-z]+(\\w|_)*"
 
 
 typeConstant : Parser s Type
 typeConstant =
-    withMeta <| TypeConstructor <$> sepBy1 (string ".") upName <*> succeed []
+    withMeta <|
+        TypeConstructor
+            <$> sepBy1 (string ".") upName
+            <*> succeed []
 
 
 typeApplication : Parser s (Type -> Type -> Type)
@@ -144,14 +149,18 @@ typeTuple : Parser s Type
 typeTuple =
     lazy <|
         \() ->
-            withMeta <| TypeTuple <$> parens (commaSeparated_ type_)
+            withMeta <|
+                TypeTuple
+                    <$> parens (commaSeparated_ type_)
 
 
 typeRecordPair : Parser s ( Name, Type )
 typeRecordPair =
     lazy <|
         \() ->
-            (,) <$> (loName <* symbol ":") <*> typeAnnotation
+            (,)
+                <$> (loName <* symbol ":")
+                <*> typeAnnotation
 
 
 typeRecordPairs : Parser s (List ( Name, Type ))
@@ -360,12 +369,16 @@ infixDeclaration =
 
 singleLineComment : Parser s Statement
 singleLineComment =
-    withMeta <| Comment <$> (string "--" *> regex ".*" <* whitespace)
+    withMeta <|
+        Comment
+            <$> (string "--" *> regex ".*" <* whitespace)
 
 
 multiLineComment : Parser s Statement
 multiLineComment =
-    withMeta <| (Comment << String.fromList) <$> (string "{-" *> manyTill anyChar (string "-}"))
+    withMeta <|
+        (Comment << String.fromList)
+            <$> (string "{-" *> manyTill anyChar (string "-}"))
 
 
 comment : Parser s Statement

--- a/tests/Expression.elm
+++ b/tests/Expression.elm
@@ -94,8 +94,11 @@ letExpressions =
                 "let a = 42 in a"
                     |> isExpression
                         (Let
-                            [ ( var "a", Integer 42 { line = 1, column = 8 } ) ]
-                            (var "a")
+                            [ ( var "a" { line = 1, column = 4 }
+                              , Integer 42 { line = 1, column = 8 }
+                              )
+                            ]
+                            (var "a" { line = 1, column = 14 })
                             { line = 1, column = 0 }
                         )
         , test "bind to _" <|
@@ -103,7 +106,7 @@ letExpressions =
                 "let _ = 42 in 24"
                     |> isExpression
                         (Let
-                            [ ( var "_", Integer 42 { line = 1, column = 8 } ) ]
+                            [ ( var "_" { line = 1, column = 4 }, Integer 42 { line = 1, column = 8 } ) ]
                             (Integer 24 { line = 1, column = 14 })
                             { line = 1, column = 0 }
                         )
@@ -112,8 +115,8 @@ letExpressions =
                 "let letter = 1 \n in letter"
                     |> isExpression
                         (Let
-                            [ ( var "letter", Integer 1 { line = 1, column = 13 } ) ]
-                            (var "letter")
+                            [ ( var "letter" { line = 1, column = 4 }, Integer 1 { line = 1, column = 13 } ) ]
+                            (var "letter" { line = 2, column = 4 })
                             { line = 1, column = 0 }
                         )
         , test "function 1" <|
@@ -126,17 +129,22 @@ in
         """
                     |> isExpression
                         (Let
-                            [ ( Application (var "f") (var "x")
+                            [ ( Application
+                                    (var "f" { line = 1, column = 1 })
+                                    (var "x" { line = 1, column = 3 })
+                                    { line = 1, column = 2 }
                               , (BinOp
-                                    (var "+")
-                                    (var "x")
+                                    (var "+" { line = 1, column = 10 })
+                                    (var "x" { line = 1, column = 7 })
                                     (Integer 1 { line = 1, column = 11 })
+                                    { line = 1, column = 10 }
                                 )
                               )
                             ]
                             (Application
-                                (var "f")
+                                (var "f" { line = 4, column = 2 })
                                 (Integer 4 { line = 4, column = 4 })
+                                { line = 4, column = 3 }
                             )
                             { line = 1, column = 0 }
                         )
@@ -151,22 +159,35 @@ in
         """
                     |> isExpression
                         (Let
-                            [ ( (Application (var "f") (var "x"))
+                            [ ( (Application
+                                    (var "f" { line = 1, column = 1 })
+                                    (var "x" { line = 1, column = 3 })
+                                    { line = 1, column = 2 }
+                                )
                               , (BinOp
-                                    (var "+")
-                                    (var "x")
+                                    (var "+" { line = 1, column = 10 })
+                                    (var "x" { line = 1, column = 7 })
                                     (Integer 1 { line = 1, column = 11 })
+                                    { line = 1, column = 10 }
                                 )
                               )
-                            , ( Application (var "g") (var "x")
+                            , ( Application
+                                    (var "g" { line = 2, column = 1 })
+                                    (var "x" { line = 2, column = 3 })
+                                    { line = 2, column = 2 }
                               , (BinOp
-                                    (var "+")
-                                    (var "x")
+                                    (var "+" { line = 2, column = 10 })
+                                    (var "x" { line = 2, column = 7 })
                                     (Integer 1 { line = 2, column = 11 })
+                                    { line = 2, column = 10 }
                                 )
                               )
                             ]
-                            (Application (var "f") (Integer 4 { line = 5, column = 4 }))
+                            (Application
+                                (var "f" { line = 5, column = 2 })
+                                (Integer 4 { line = 5, column = 4 })
+                                { line = 5, column = 3 }
+                            )
                             { line = 1, column = 0 }
                         )
         , test "multiple bindings" <|
@@ -181,16 +202,19 @@ in
             """
                     |> isExpression
                         (Let
-                            [ ( var "a", Integer 42 { line = 1, column = 5 } )
-                            , ( var "b"
+                            [ ( var "a" { line = 1, column = 1 }
+                              , Integer 42 { line = 1, column = 5 }
+                              )
+                            , ( var "b" { line = 3, column = 1 }
                               , (BinOp
-                                    (var "+")
-                                    (var "a")
+                                    (var "+" { line = 3, column = 8 })
+                                    (var "a" { line = 3, column = 5 })
                                     (Integer 1 { line = 3, column = 9 })
+                                    { line = 3, column = 8 }
                                 )
                               )
                             ]
-                            (var "b")
+                            (var "b" { line = 6, column = 2 })
                             { line = 1, column = 0 }
                         )
         ]
@@ -211,9 +235,16 @@ case x of
           """
                     |> isExpression
                         (Case
-                            (var "x")
-                            [ ( var "Nothing", Integer 0 { line = 2, column = 3 } )
-                            , ( Application (var "Just") (var "y"), (var "y") )
+                            (var "x" { line = 1, column = 5 })
+                            [ ( var "Nothing" { line = 1, column = 1 }
+                              , Integer 0 { line = 2, column = 3 }
+                              )
+                            , ( Application
+                                    (var "Just" { line = 4, column = 1 })
+                                    (var "y" { line = 4, column = 6 })
+                                    { line = 4, column = 5 }
+                              , (var "y" { line = 6, column = 4 })
+                              )
                             ]
                             { line = 1, column = 0 }
                         )
@@ -226,8 +257,11 @@ case x of
           """
                     |> isExpression
                         (Case
-                            (var "x")
-                            [ ( var "_", Integer 42 { line = 3, column = 4 } ) ]
+                            (var "x" { line = 1, column = 5 })
+                            [ ( var "_" { line = 1, column = 1 }
+                              , Integer 42 { line = 3, column = 4 }
+                              )
+                            ]
                             { line = 1, column = 0 }
                         )
         ]
@@ -241,8 +275,9 @@ application =
                 "f a"
                     |> isExpression
                         (Application
-                            (var "f")
-                            (var "a")
+                            (var "f" { line = 1, column = 0 })
+                            (var "a" { line = 1, column = 2 })
+                            { line = 1, column = 1 }
                         )
         , test "curried application" <|
             \() ->
@@ -250,10 +285,12 @@ application =
                     |> isExpression
                         (Application
                             (Application
-                                (var "f")
-                                (var "a")
+                                (var "f" { line = 1, column = 0 })
+                                (var "a" { line = 1, column = 2 })
+                                { line = 1, column = 1 }
                             )
-                            (var "b")
+                            (var "b" { line = 1, column = 4 })
+                            { line = 1, column = 3 }
                         )
         , test "curried application with parens" <|
             \() ->
@@ -261,10 +298,12 @@ application =
                     |> isExpression
                         (Application
                             (Application
-                                (var "f")
-                                (var "a")
+                                (var "f" { line = 1, column = 1 })
+                                (var "a" { line = 1, column = 3 })
+                                { line = 1, column = 2 }
                             )
-                            (var "b")
+                            (var "b" { line = 1, column = 6 })
+                            { line = 1, column = 5 }
                         )
         , test "multiline application" <|
             \() ->
@@ -272,26 +311,30 @@ application =
                     |> isExpression
                         (Application
                             (Application
-                                (var "f")
-                                (var "a")
+                                (var "f" { line = 1, column = 0 })
+                                (var "a" { line = 1, column = 0 })
+                                { line = 1, column = 0 }
                             )
-                            (var "b")
+                            (var "b" { line = 3, column = 1 })
+                            { line = 3, column = 0 }
                         )
         , test "multiline bug" <|
             \() ->
                 "f\n (==)"
                     |> isExpression
                         (Application
-                            (var "f")
-                            (var "==")
+                            (var "f" { line = 1, column = 0 })
+                            (var "==" { line = 1, column = 0 })
+                            { line = 1, column = 0 }
                         )
         , test "same multiline bug" <|
             \() ->
                 "f\n \"I like the symbol =\""
                     |> isExpression
                         (Application
-                            (var "f")
+                            (var "f" { line = 1, column = 0 })
                             (String "I like the symbol =" { line = 2, column = 1 })
+                            { line = 2, column = 0 }
                         )
         , test "constructor application" <|
             \() ->
@@ -299,10 +342,12 @@ application =
                     |> isExpression
                         (Application
                             (Application
-                                (var "Cons")
-                                (var "a")
+                                (var "Cons" { line = 1, column = 0 })
+                                (var "a" { line = 1, column = 5 })
+                                { line = 1, column = 4 }
                             )
-                            (var "Nil")
+                            (var "Nil" { line = 1, column = 7 })
+                            { line = 1, column = 6 }
                         )
         ]
 
@@ -311,14 +356,14 @@ tuple : Test
 tuple =
     describe "Tuples"
         [ test "Empty tuple" <|
-            \() -> "()" |> isExpression (var "()")
+            \() -> "()" |> isExpression (var "()" { line = 1, column = 0 })
         , test "Simple tuple" <|
             \() ->
                 "(a, b)"
                     |> isExpression
                         (Tuple
-                            [ (var "a")
-                            , (var "b")
+                            [ (var "a" { line = 1, column = 1 })
+                            , (var "b" { line = 1, column = 4 })
                             ]
                             { line = 1, column = 0 }
                         )
@@ -327,8 +372,8 @@ tuple =
                 "( a, b )"
                     |> isExpression
                         (Tuple
-                            [ (var "a")
-                            , (var "b")
+                            [ (var "a" { line = 1, column = 2 })
+                            , (var "b" { line = 1, column = 5 })
                             ]
                             { line = 1, column = 0 }
                         )
@@ -356,14 +401,14 @@ list =
                     |> isExpression
                         (List
                             [ (Tuple
-                                [ (var "a")
-                                , (var "b")
+                                [ (var "a" { line = 1, column = 2 })
+                                , (var "b" { line = 1, column = 5 })
                                 ]
                                 { line = 1, column = 1 }
                               )
                             , (Tuple
-                                [ (var "a")
-                                , (var "b")
+                                [ (var "a" { line = 1, column = 10 })
+                                , (var "b" { line = 1, column = 13 })
                                 ]
                                 { line = 1, column = 9 }
                               )
@@ -380,13 +425,17 @@ record =
             \() ->
                 "{a = b}"
                     |> isExpression
-                        (Record [ ( "a", (var "b") ) ] { line = 1, column = 0 })
+                        (Record
+                            [ ( "a", (var "b" { line = 1, column = 5 }) )
+                            ]
+                            { line = 1, column = 0 }
+                        )
         , test "Simple record with many fields" <|
             \() ->
                 "{a = b, b = 2}"
                     |> isExpression
                         (Record
-                            [ ( "a", (var "b") )
+                            [ ( "a", (var "b" { line = 1, column = 5 }) )
                             , ( "b", (Integer 2 { line = 1, column = 12 }) )
                             ]
                             { line = 1, column = 0 }
@@ -398,16 +447,16 @@ record =
                         (Record
                             [ ( "a"
                               , (Tuple
-                                    [ (var "a")
-                                    , (var "b")
+                                    [ (var "a" { line = 1, column = 6 })
+                                    , (var "b" { line = 1, column = 9 })
                                     ]
                                     { line = 1, column = 5 }
                                 )
                               )
                             , ( "b"
                               , (Tuple
-                                    [ (var "a")
-                                    , (var "b")
+                                    [ (var "a" { line = 1, column = 18 })
+                                    , (var "b" { line = 1, column = 21 })
                                     ]
                                     { line = 1, column = 17 }
                                 )
@@ -433,8 +482,9 @@ record =
                         (Record
                             [ ( "a"
                               , (Application
-                                    (var "Just")
+                                    (var "Just" { line = 1, column = 5 })
                                     (Integer 2 { line = 1, column = 10 })
+                                    { line = 1, column = 9 }
                                 )
                               )
                             ]
@@ -448,8 +498,9 @@ record =
                             "a"
                             [ ( "a"
                               , (Application
-                                    (var "Just")
+                                    (var "Just" { line = 1, column = 9 })
                                     (Integer 2 { line = 1, column = 14 })
+                                    { line = 1, column = 13 }
                                 )
                               )
                             ]
@@ -460,12 +511,8 @@ record =
                 "{a, b}"
                     |> isExpression
                         (Record
-                            [ ( "a"
-                              , var "a"
-                              )
-                            , ( "b"
-                              , var "b"
-                              )
+                            [ ( "a", var "a" { line = 1, column = 1 } )
+                            , ( "b", var "b" { line = 1, column = 4 } )
                             ]
                             { line = 1, column = 0 }
                         )
@@ -476,37 +523,44 @@ expressions : Test
 expressions =
     describe "Expressions"
         [ test "Operator in parens" <|
-            \() -> "(+)" |> isExpression (var "+")
+            \() -> "(+)" |> isExpression (var "+" { line = 1, column = 0 })
         , test "Operators passed to map" <|
             \() ->
                 "reduce (+) list"
                     |> isExpression
                         (Application
                             (Application
-                                (var "reduce")
-                                (var "+")
+                                (var "reduce" { line = 1, column = 0 })
+                                (var "+" { line = 1, column = 0 })
+                                { line = 1, column = 0 }
                             )
-                            (var "list")
+                            (var "list" { line = 1, column = 0 })
+                            { line = 1, column = 0 }
                         )
         , test "partial application" <|
             \() ->
                 "(+) 2"
                     |> isExpression
                         (Application
-                            (var "+")
+                            (var "+" { line = 1, column = 0 })
                             (Integer 2 { line = 1, column = 4 })
+                            { line = 1, column = 0 }
                         )
         , test "Case with as" <|
             \() ->
                 "case a of \nT _ as x -> 1"
                     |> isExpression
                         (Case
-                            (var "a")
-                            ([ ( BinOp (var "as")
-                                    (Application (var "T")
-                                        (var "_")
+                            (var "a" { line = 1, column = 5 })
+                            ([ ( BinOp
+                                    (var "as" { line = 2, column = 4 })
+                                    (Application
+                                        (var "T" { line = 2, column = 0 })
+                                        (var "_" { line = 2, column = 2 })
+                                        { line = 2, column = 1 }
                                     )
-                                    (var "x")
+                                    (var "x" { line = 2, column = 7 })
+                                    { line = 2, column = 4 }
                                , Integer 1 { line = 2, column = 12 }
                                )
                              ]
@@ -517,18 +571,34 @@ expressions =
             \() ->
                 "a :: b :: c"
                     |> isExpression
-                        (BinOp (var "::")
-                            (var "a")
-                            (BinOp (var "::") (var "b") (var "c"))
+                        (BinOp
+                            (var "::" { line = 1, column = 4 })
+                            (var "a" { line = 1, column = 0 })
+                            (BinOp
+                                (var "::" { line = 1, column = 9 })
+                                (var "b" { line = 1, column = 5 })
+                                (var "c" { line = 1, column = 10 })
+                                { line = 1, column = 9 }
+                            )
+                            { line = 1, column = 4 }
                         )
         , test "cons has right assoc with tuple" <|
             \() ->
                 "(a, a :: b :: c)"
                     |> isExpression
                         (Tuple
-                            [ (var "a")
-                            , ((BinOp (var "::") (var "a"))
-                                (BinOp (var "::") (var "b") (var "c"))
+                            [ (var "a" { line = 1, column = 1 })
+                            , ((BinOp
+                                    (var "::" { line = 1, column = 8 })
+                                    (var "a" { line = 1, column = 4 })
+                               )
+                                (BinOp
+                                    (var "::" { line = 1, column = 13 })
+                                    (var "b" { line = 1, column = 9 })
+                                    (var "c" { line = 1, column = 14 })
+                                    { line = 1, column = 13 }
+                                )
+                                { line = 1, column = 8 }
                               )
                             ]
                             { line = 1, column = 0 }
@@ -538,7 +608,14 @@ expressions =
                 "\\(a,b) acc -> 1"
                     |> isExpression
                         (Lambda
-                            [ (Tuple [ (var "a"), (var "b") ] { line = 1, column = 1 }), (var "acc") ]
+                            [ (Tuple
+                                [ (var "a" { line = 1, column = 2 })
+                                , (var "b" { line = 1, column = 4 })
+                                ]
+                                { line = 1, column = 1 }
+                              )
+                            , (var "acc" { line = 1, column = 7 })
+                            ]
                             (Integer 1 { line = 1, column = 14 })
                             { line = 1, column = 0 }
                         )
@@ -547,7 +624,12 @@ expressions =
                 "let (a,b) = (1,2) in a"
                     |> isExpression
                         (Let
-                            [ ( (Tuple [ (var "a"), (var "b") ] { line = 1, column = 4 })
+                            [ ( (Tuple
+                                    [ (var "a" { line = 1, column = 5 })
+                                    , (var "b" { line = 1, column = 7 })
+                                    ]
+                                    { line = 1, column = 4 }
+                                )
                               , (Tuple
                                     [ Integer 1
                                         { line = 1, column = 13 }
@@ -557,22 +639,29 @@ expressions =
                                 )
                               )
                             ]
-                            (var "a")
+                            (var "a" { line = 1, column = 21 })
                             { line = 1, column = 0 }
                         )
         , test "Access" <|
             \() ->
                 "Module.a"
                     |> isExpression
-                        (Access (var "Module") [ "a" ] { line = 1, column = 0 })
+                        (Access
+                            (var "Module" { line = 1, column = 0 })
+                            [ "a" ]
+                            { line = 1, column = 0 }
+                        )
         , test "AccessFunction" <|
             \() ->
                 "map .a list"
                     |> isExpression
                         (Application
-                            (Application (var "map")
+                            (Application
+                                (var "map" { line = 1, column = 0 })
                                 (AccessFunction "a" { line = 1, column = 4 })
+                                { line = 1, column = 3 }
                             )
-                            (var "list")
+                            (var "list" { line = 1, column = 7 })
+                            { line = 1, column = 6 }
                         )
         ]

--- a/tests/Expression.elm
+++ b/tests/Expression.elm
@@ -324,8 +324,8 @@ application =
                     |> isExpression
                         (Application
                             (var "f" { line = 1, column = 0 })
-                            (var "==" { line = 1, column = 0 })
-                            { line = 1, column = 0 }
+                            (var "==" { line = 2, column = 1 })
+                            { line = 2, column = 0 }
                         )
         , test "same multiline bug" <|
             \() ->
@@ -524,18 +524,18 @@ expressions =
     describe "Expressions"
         [ test "Operator in parens" <|
             \() -> "(+)" |> isExpression (var "+" { line = 1, column = 0 })
-        , test "Operators passed to map" <|
+        , test "Operator passed to map" <|
             \() ->
                 "reduce (+) list"
                     |> isExpression
                         (Application
                             (Application
                                 (var "reduce" { line = 1, column = 0 })
-                                (var "+" { line = 1, column = 0 })
-                                { line = 1, column = 0 }
+                                (var "+" { line = 1, column = 7 })
+                                { line = 1, column = 6 }
                             )
-                            (var "list" { line = 1, column = 0 })
-                            { line = 1, column = 0 }
+                            (var "list" { line = 1, column = 11 })
+                            { line = 1, column = 10 }
                         )
         , test "partial application" <|
             \() ->
@@ -544,7 +544,7 @@ expressions =
                         (Application
                             (var "+" { line = 1, column = 0 })
                             (Integer 2 { line = 1, column = 4 })
-                            { line = 1, column = 0 }
+                            { line = 1, column = 3 }
                         )
         , test "Case with as" <|
             \() ->

--- a/tests/Expression.elm
+++ b/tests/Expression.elm
@@ -20,19 +20,15 @@ import Test exposing (describe, test, Test)
 import Helpers exposing (var, fails, isExpression)
 
 
-meta =
-    { line = 0, column = 0 }
-
-
 characterLiterals : Test
 characterLiterals =
     describe "Character literals"
         [ test "character literal" <|
-            \() -> "'a'" |> isExpression (Character 'a' meta)
+            \() -> "'a'" |> isExpression (Character 'a' { line = 1, column = 0 })
         , test "newline literal" <|
-            \() -> "'\n'" |> isExpression (Character '\n' meta)
+            \() -> "'\n'" |> isExpression (Character '\n' { line = 1, column = 0 })
         , test "Charcode literals" <|
-            \() -> "'\\x23'" |> isExpression (Character '#' meta)
+            \() -> "'\\x23'" |> isExpression (Character '#' { line = 1, column = 0 })
         , test "character literals must contain one character" <|
             \() -> fails "''"
         ]
@@ -42,11 +38,11 @@ intLiterals : Test
 intLiterals =
     describe "Integer literals"
         [ test "integer literal" <|
-            \() -> "0" |> isExpression (Integer 0 meta)
+            \() -> "0" |> isExpression (Integer 0 { line = 1, column = 0 })
         , test "positive literal" <|
-            \() -> "+12" |> isExpression (Integer 12 meta)
+            \() -> "+12" |> isExpression (Integer 12 { line = 1, column = 0 })
         , test "negative literal" <|
-            \() -> "-12" |> isExpression (Integer -12 meta)
+            \() -> "-12" |> isExpression (Integer -12 { line = 1, column = 0 })
         ]
 
 
@@ -54,11 +50,11 @@ floatLiterals : Test
 floatLiterals =
     describe "Float literals"
         [ test "float literal" <|
-            \() -> "0.5" |> isExpression (Float 0.5 meta)
+            \() -> "0.5" |> isExpression (Float 0.5 { line = 1, column = 0 })
         , test "positive literal" <|
-            \() -> "+12.5" |> isExpression (Float 12.5 meta)
+            \() -> "+12.5" |> isExpression (Float 12.5 { line = 1, column = 0 })
         , test "negative literal" <|
-            \() -> "-12.5" |> isExpression (Float -12.5 meta)
+            \() -> "-12.5" |> isExpression (Float -12.5 { line = 1, column = 0 })
         ]
 
 
@@ -66,17 +62,17 @@ stringLiterals : Test
 stringLiterals =
     describe "String literals"
         [ test "empty string" <|
-            \() -> "\"\"" |> isExpression (String "" meta)
+            \() -> "\"\"" |> isExpression (String "" { line = 1, column = 0 })
         , test "simple string" <|
-            \() -> "\"hello\"" |> isExpression (String "hello" meta)
+            \() -> "\"hello\"" |> isExpression (String "hello" { line = 1, column = 0 })
         , test "escaped string" <|
-            \() -> "\"hello, \\\"world\\\"\"" |> isExpression (String "hello, \\\"world\\\"" meta)
+            \() -> "\"hello, \\\"world\\\"\"" |> isExpression (String "hello, \\\"world\\\"" { line = 1, column = 0 })
         , test "triple-quoted string" <|
-            \() -> "\"\"\"\"\"\"" |> isExpression (String "" meta)
+            \() -> "\"\"\"\"\"\"" |> isExpression (String "" { line = 1, column = 0 })
         , test "multi-line strings" <|
-            \() -> "\"\"\"hello\nworld\"\"\"" |> isExpression (String "hello\nworld" meta)
+            \() -> "\"\"\"hello\nworld\"\"\"" |> isExpression (String "hello\nworld" { line = 1, column = 0 })
         , test "double escaped string" <|
-            \() -> "\"\\\\\"" |> isExpression (String "\\\\" meta)
+            \() -> "\"\\\\\"" |> isExpression (String "\\\\" { line = 1, column = 0 })
         ]
 
 
@@ -98,27 +94,27 @@ letExpressions =
                 "let a = 42 in a"
                     |> isExpression
                         (Let
-                            [ ( var "a", Integer 42 meta ) ]
+                            [ ( var "a", Integer 42 { line = 1, column = 8 } ) ]
                             (var "a")
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "bind to _" <|
             \() ->
                 "let _ = 42 in 24"
                     |> isExpression
                         (Let
-                            [ ( var "_", Integer 42 meta ) ]
-                            (Integer 24 meta)
-                            meta
+                            [ ( var "_", Integer 42 { line = 1, column = 8 } ) ]
+                            (Integer 24 { line = 1, column = 14 })
+                            { line = 1, column = 0 }
                         )
         , test "Can start with a tag name" <|
             \() ->
                 "let letter = 1 \n in letter"
                     |> isExpression
                         (Let
-                            [ ( var "letter", Integer 1 meta ) ]
+                            [ ( var "letter", Integer 1 { line = 1, column = 13 } ) ]
                             (var "letter")
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "function 1" <|
             \() ->
@@ -131,11 +127,18 @@ in
                     |> isExpression
                         (Let
                             [ ( Application (var "f") (var "x")
-                              , (BinOp (var "+") (var "x") (Integer 1 meta))
+                              , (BinOp
+                                    (var "+")
+                                    (var "x")
+                                    (Integer 1 { line = 1, column = 11 })
+                                )
                               )
                             ]
-                            (Application (var "f") (Integer 4 meta))
-                            meta
+                            (Application
+                                (var "f")
+                                (Integer 4 { line = 4, column = 4 })
+                            )
+                            { line = 1, column = 0 }
                         )
         , test "function 2" <|
             \() ->
@@ -149,14 +152,22 @@ in
                     |> isExpression
                         (Let
                             [ ( (Application (var "f") (var "x"))
-                              , (BinOp (var "+") (var "x") (Integer 1 meta))
+                              , (BinOp
+                                    (var "+")
+                                    (var "x")
+                                    (Integer 1 { line = 1, column = 11 })
+                                )
                               )
                             , ( Application (var "g") (var "x")
-                              , (BinOp (var "+") (var "x") (Integer 1 meta))
+                              , (BinOp
+                                    (var "+")
+                                    (var "x")
+                                    (Integer 1 { line = 2, column = 11 })
+                                )
                               )
                             ]
-                            (Application (var "f") (Integer 4 meta))
-                            meta
+                            (Application (var "f") (Integer 4 { line = 5, column = 4 }))
+                            { line = 1, column = 0 }
                         )
         , test "multiple bindings" <|
             \() ->
@@ -170,11 +181,17 @@ in
             """
                     |> isExpression
                         (Let
-                            [ ( var "a", Integer 42 meta )
-                            , ( var "b", (BinOp (var "+") (var "a") (Integer 1 meta)) )
+                            [ ( var "a", Integer 42 { line = 1, column = 5 } )
+                            , ( var "b"
+                              , (BinOp
+                                    (var "+")
+                                    (var "a")
+                                    (Integer 1 { line = 3, column = 9 })
+                                )
+                              )
                             ]
                             (var "b")
-                            meta
+                            { line = 1, column = 0 }
                         )
         ]
 
@@ -195,10 +212,10 @@ case x of
                     |> isExpression
                         (Case
                             (var "x")
-                            [ ( var "Nothing", Integer 0 meta )
+                            [ ( var "Nothing", Integer 0 { line = 2, column = 3 } )
                             , ( Application (var "Just") (var "y"), (var "y") )
                             ]
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "binding to underscore" <|
             \() ->
@@ -210,8 +227,8 @@ case x of
                     |> isExpression
                         (Case
                             (var "x")
-                            [ ( var "_", Integer 42 meta ) ]
-                            meta
+                            [ ( var "_", Integer 42 { line = 3, column = 4 } ) ]
+                            { line = 1, column = 0 }
                         )
         ]
 
@@ -274,7 +291,7 @@ application =
                     |> isExpression
                         (Application
                             (var "f")
-                            (String "I like the symbol =" meta)
+                            (String "I like the symbol =" { line = 2, column = 1 })
                         )
         , test "constructor application" <|
             \() ->
@@ -303,7 +320,7 @@ tuple =
                             [ (var "a")
                             , (var "b")
                             ]
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "Simple tuple with format" <|
             \() ->
@@ -313,7 +330,7 @@ tuple =
                             [ (var "a")
                             , (var "b")
                             ]
-                            meta
+                            { line = 1, column = 0 }
                         )
         ]
 
@@ -321,9 +338,18 @@ tuple =
 list : Test
 list =
     describe "Lists"
-        [ test "Empty list" <| \() -> "[]" |> isExpression (List [] meta)
+        [ test "Empty list" <| \() -> "[]" |> isExpression (List [] { line = 1, column = 0 })
         , test "Simple list" <|
-            \() -> "[1, 2]" |> isExpression (List [ Integer 1 meta, Integer 2 meta ] meta)
+            \() ->
+                "[1, 2]"
+                    |> isExpression
+                        (List
+                            [ Integer 1
+                                { line = 1, column = 1 }
+                            , Integer 2 { line = 1, column = 4 }
+                            ]
+                            { line = 1, column = 0 }
+                        )
         , test "Tuple list" <|
             \() ->
                 "[(a, b), (a, b)]"
@@ -333,16 +359,16 @@ list =
                                 [ (var "a")
                                 , (var "b")
                                 ]
-                                meta
+                                { line = 1, column = 1 }
                               )
                             , (Tuple
                                 [ (var "a")
                                 , (var "b")
                                 ]
-                                meta
+                                { line = 1, column = 9 }
                               )
                             ]
-                            meta
+                            { line = 1, column = 0 }
                         )
         ]
 
@@ -354,16 +380,16 @@ record =
             \() ->
                 "{a = b}"
                     |> isExpression
-                        (Record [ ( "a", (var "b") ) ] meta)
+                        (Record [ ( "a", (var "b") ) ] { line = 1, column = 0 })
         , test "Simple record with many fields" <|
             \() ->
                 "{a = b, b = 2}"
                     |> isExpression
                         (Record
                             [ ( "a", (var "b") )
-                            , ( "b", (Integer 2 meta) )
+                            , ( "b", (Integer 2 { line = 1, column = 12 }) )
                             ]
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "Simple record with many tuple fields" <|
             \() ->
@@ -375,7 +401,7 @@ record =
                                     [ (var "a")
                                     , (var "b")
                                     ]
-                                    meta
+                                    { line = 1, column = 5 }
                                 )
                               )
                             , ( "b"
@@ -383,11 +409,11 @@ record =
                                     [ (var "a")
                                     , (var "b")
                                     ]
-                                    meta
+                                    { line = 1, column = 17 }
                                 )
                               )
                             ]
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "Simple record with updated field" <|
             \() ->
@@ -395,10 +421,10 @@ record =
                     |> isExpression
                         (RecordUpdate
                             "a"
-                            [ ( "b", (Integer 2 meta) )
-                            , ( "c", (Integer 3 meta) )
+                            [ ( "b", (Integer 2 { line = 1, column = 9 }) )
+                            , ( "c", (Integer 3 { line = 1, column = 16 }) )
                             ]
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "Simple record with advanced field" <|
             \() ->
@@ -408,11 +434,11 @@ record =
                             [ ( "a"
                               , (Application
                                     (var "Just")
-                                    (Integer 2 meta)
+                                    (Integer 2 { line = 1, column = 10 })
                                 )
                               )
                             ]
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "Simple update record with advanced field" <|
             \() ->
@@ -423,11 +449,11 @@ record =
                             [ ( "a"
                               , (Application
                                     (var "Just")
-                                    (Integer 2 meta)
+                                    (Integer 2 { line = 1, column = 14 })
                                 )
                               )
                             ]
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "Simplified record destructuring pattern" <|
             \() ->
@@ -441,7 +467,7 @@ record =
                               , var "b"
                               )
                             ]
-                            meta
+                            { line = 1, column = 0 }
                         )
         ]
 
@@ -463,7 +489,13 @@ expressions =
                             (var "list")
                         )
         , test "partial application" <|
-            \() -> "(+) 2" |> isExpression (Application (var "+") (Integer 2 meta))
+            \() ->
+                "(+) 2"
+                    |> isExpression
+                        (Application
+                            (var "+")
+                            (Integer 2 { line = 1, column = 4 })
+                        )
         , test "Case with as" <|
             \() ->
                 "case a of \nT _ as x -> 1"
@@ -475,11 +507,11 @@ expressions =
                                         (var "_")
                                     )
                                     (var "x")
-                               , Integer 1 meta
+                               , Integer 1 { line = 2, column = 12 }
                                )
                              ]
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "cons has right assoc" <|
             \() ->
@@ -499,37 +531,48 @@ expressions =
                                 (BinOp (var "::") (var "b") (var "c"))
                               )
                             ]
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "Destructuring lambda" <|
             \() ->
                 "\\(a,b) acc -> 1"
                     |> isExpression
                         (Lambda
-                            [ (Tuple [ (var "a"), (var "b") ] meta), (var "acc") ]
-                            (Integer 1 meta)
-                            meta
+                            [ (Tuple [ (var "a"), (var "b") ] { line = 1, column = 1 }), (var "acc") ]
+                            (Integer 1 { line = 1, column = 14 })
+                            { line = 1, column = 0 }
                         )
         , test "Destructuring Let" <|
             \() ->
                 "let (a,b) = (1,2) in a"
                     |> isExpression
                         (Let
-                            [ ( (Tuple [ (var "a"), (var "b") ] meta)
-                              , (Tuple [ Integer 1 meta, Integer 2 meta ] meta)
+                            [ ( (Tuple [ (var "a"), (var "b") ] { line = 1, column = 4 })
+                              , (Tuple
+                                    [ Integer 1
+                                        { line = 1, column = 13 }
+                                    , Integer 2 { line = 1, column = 15 }
+                                    ]
+                                    { line = 1, column = 12 }
+                                )
                               )
                             ]
                             (var "a")
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "Access" <|
             \() ->
                 "Module.a"
                     |> isExpression
-                        (Access (var "Module") [ "a" ] meta)
+                        (Access (var "Module") [ "a" ] { line = 1, column = 0 })
         , test "AccessFunction" <|
             \() ->
                 "map .a list"
                     |> isExpression
-                        (Application (Application (var "map") (AccessFunction "a" meta)) (var "list"))
+                        (Application
+                            (Application (var "map")
+                                (AccessFunction "a" { line = 1, column = 4 })
+                            )
+                            (var "list")
+                        )
         ]

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -3,13 +3,13 @@ module Helpers
         ( isExpression
         , isStatement
         , areStatements
-        , isApplication
         , fails
         , var
         )
 
 import Ast exposing (parse, parseExpression, parseStatement)
 import Ast.BinOp exposing (operators)
+import Ast.Helpers
 import Ast.Expression exposing (Expression(..))
 import Ast.Statement exposing (ExportSet(..), Type(..), Statement(..))
 import Expect exposing (..)
@@ -37,11 +37,6 @@ isExpression e i =
 
         Err ( _, { position }, es ) ->
             Expect.fail ("failed to parse: " ++ i ++ " at position " ++ toString position ++ " with errors: " ++ toString es)
-
-
-isApplication : Expression -> List Expression -> String -> Expectation
-isApplication fn args =
-    isExpression (List.foldl (flip Application) fn args)
 
 
 isStatement : Statement -> String -> Expectation

--- a/tests/Multiline.elm
+++ b/tests/Multiline.elm
@@ -3,27 +3,61 @@ module Multiline exposing (application)
 import Ast exposing (parseExpression, parseStatement)
 import Ast.BinOp exposing (operators)
 import Ast.Expression exposing (..)
-import Test exposing (describe, test, Test)
-import Helpers exposing (isApplication, var)
+import Test exposing (describe, test, skip, Test)
+import Helpers exposing (isExpression, var)
 
 
 application : Test
 application =
-    describe "Multiline performance"
-        [ test "Application" <|
-            \() ->
-                "fn\n a\n b\n c\n d\n e\n f\n g\n h\n i\n j\n k"
-                    |> isApplication (var "fn")
-                        [ var "a"
-                        , var "b"
-                        , var "c"
-                        , var "d"
-                        , var "e"
-                        , var "f"
-                        , var "g"
-                        , var "h"
-                        , var "i"
-                        , var "j"
-                        , var "k"
-                        ]
-        ]
+    skip <|
+        describe "Multiline performance"
+            [ test "Application" <|
+                \() ->
+                    "fn\n a\n b\n c\n d\n e\n f\n g\n h\n i\n j\n k"
+                        |> isExpression
+                            (Application
+                                (Application
+                                    (Application
+                                        (Application
+                                            (Application
+                                                (Application
+                                                    (Application
+                                                        (Application
+                                                            (Application
+                                                                (Application
+                                                                    (Application
+                                                                        (var "fn" { line = 1, column = 0 })
+                                                                        (var "a" { line = 1, column = 0 })
+                                                                        { line = 1, column = 0 }
+                                                                    )
+                                                                    (var "b" { line = 2, column = 0 })
+                                                                    { line = 2, column = 0 }
+                                                                )
+                                                                (var "c" { line = 3, column = 0 })
+                                                                { line = 3, column = 0 }
+                                                            )
+                                                            (var "d" { line = 4, column = 0 })
+                                                            { line = 4, column = 0 }
+                                                        )
+                                                        (var "e" { line = 5, column = 0 })
+                                                        { line = 5, column = 0 }
+                                                    )
+                                                    (var "f" { line = 6, column = 0 })
+                                                    { line = 6, column = 0 }
+                                                )
+                                                (var "g" { line = 7, column = 0 })
+                                                { line = 7, column = 0 }
+                                            )
+                                            (var "h" { line = 8, column = 0 })
+                                            { line = 8, column = 0 }
+                                        )
+                                        (var "i" { line = 9, column = 0 })
+                                        { line = 9, column = 0 }
+                                    )
+                                    (var "j" { line = 10, column = 0 })
+                                    { line = 10, column = 0 }
+                                )
+                                (var "k" { line = 12, column = 1 })
+                                { line = 12, column = 0 }
+                            )
+            ]

--- a/tests/Multiline.elm
+++ b/tests/Multiline.elm
@@ -13,50 +13,20 @@ application =
         [ test "Application" <|
             \() ->
                 "fn\n a\n b\n c\n d\n e\n f\n g\n h\n i\n j\n k"
-                    |> isExpression
-                        (Application
-                            (Application
-                                (Application
-                                    (Application
-                                        (Application
-                                            (Application
-                                                (Application
-                                                    (Application
-                                                        (Application
-                                                            (Application
-                                                                (Application
-                                                                    (var "fn" { line = 1, column = 0 })
-                                                                    (var "a" { line = 1, column = 0 })
-                                                                    { line = 1, column = 0 }
-                                                                )
-                                                                (var "b" { line = 2, column = 0 })
-                                                                { line = 2, column = 0 }
-                                                            )
-                                                            (var "c" { line = 3, column = 0 })
-                                                            { line = 3, column = 0 }
-                                                        )
-                                                        (var "d" { line = 4, column = 0 })
-                                                        { line = 4, column = 0 }
-                                                    )
-                                                    (var "e" { line = 5, column = 0 })
-                                                    { line = 5, column = 0 }
-                                                )
-                                                (var "f" { line = 6, column = 0 })
-                                                { line = 6, column = 0 }
-                                            )
-                                            (var "g" { line = 7, column = 0 })
-                                            { line = 7, column = 0 }
-                                        )
-                                        (var "h" { line = 8, column = 0 })
-                                        { line = 8, column = 0 }
-                                    )
-                                    (var "i" { line = 9, column = 0 })
-                                    { line = 9, column = 0 }
-                                )
-                                (var "j" { line = 10, column = 0 })
-                                { line = 10, column = 0 }
-                            )
-                            (var "k" { line = 12, column = 1 })
-                            { line = 12, column = 0 }
-                        )
+                    |> isExpression (makeApplication "fn" ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"])
+
         ]
+
+
+makeApplication : String -> List String -> Expression
+makeApplication name args =
+    let
+        line n =
+            { line = n + 1, column = 0 }
+
+        nextArgs ( index, name ) acc =
+            Application acc (var name <| line index) (line index)
+    in
+        args
+            |> List.indexedMap (,)
+            |> List.foldl nextArgs (var name (line 0))

--- a/tests/Multiline.elm
+++ b/tests/Multiline.elm
@@ -3,18 +3,18 @@ module Multiline exposing (application)
 import Ast exposing (parseExpression, parseStatement)
 import Ast.BinOp exposing (operators)
 import Ast.Expression exposing (..)
-import Test exposing (describe, test, skip, Test)
+import Test exposing (describe, test, Test)
 import Helpers exposing (isExpression, var)
 
 
 application : Test
 application =
-    skip <|
-        describe "Multiline performance"
-            [ test "Application" <|
-                \() ->
-                    "fn\n a\n b\n c\n d\n e\n f\n g\n h\n i\n j\n k"
-                        |> isExpression
+    describe "Multiline performance"
+        [ test "Application" <|
+            \() ->
+                "fn\n a\n b\n c\n d\n e\n f\n g\n h\n i\n j\n k"
+                    |> isExpression
+                        (Application
                             (Application
                                 (Application
                                     (Application
@@ -25,39 +25,38 @@ application =
                                                         (Application
                                                             (Application
                                                                 (Application
-                                                                    (Application
-                                                                        (var "fn" { line = 1, column = 0 })
-                                                                        (var "a" { line = 1, column = 0 })
-                                                                        { line = 1, column = 0 }
-                                                                    )
-                                                                    (var "b" { line = 2, column = 0 })
-                                                                    { line = 2, column = 0 }
+                                                                    (var "fn" { line = 1, column = 0 })
+                                                                    (var "a" { line = 1, column = 0 })
+                                                                    { line = 1, column = 0 }
                                                                 )
-                                                                (var "c" { line = 3, column = 0 })
-                                                                { line = 3, column = 0 }
+                                                                (var "b" { line = 2, column = 0 })
+                                                                { line = 2, column = 0 }
                                                             )
-                                                            (var "d" { line = 4, column = 0 })
-                                                            { line = 4, column = 0 }
+                                                            (var "c" { line = 3, column = 0 })
+                                                            { line = 3, column = 0 }
                                                         )
-                                                        (var "e" { line = 5, column = 0 })
-                                                        { line = 5, column = 0 }
+                                                        (var "d" { line = 4, column = 0 })
+                                                        { line = 4, column = 0 }
                                                     )
-                                                    (var "f" { line = 6, column = 0 })
-                                                    { line = 6, column = 0 }
+                                                    (var "e" { line = 5, column = 0 })
+                                                    { line = 5, column = 0 }
                                                 )
-                                                (var "g" { line = 7, column = 0 })
-                                                { line = 7, column = 0 }
+                                                (var "f" { line = 6, column = 0 })
+                                                { line = 6, column = 0 }
                                             )
-                                            (var "h" { line = 8, column = 0 })
-                                            { line = 8, column = 0 }
+                                            (var "g" { line = 7, column = 0 })
+                                            { line = 7, column = 0 }
                                         )
-                                        (var "i" { line = 9, column = 0 })
-                                        { line = 9, column = 0 }
+                                        (var "h" { line = 8, column = 0 })
+                                        { line = 8, column = 0 }
                                     )
-                                    (var "j" { line = 10, column = 0 })
-                                    { line = 10, column = 0 }
+                                    (var "i" { line = 9, column = 0 })
+                                    { line = 9, column = 0 }
                                 )
-                                (var "k" { line = 12, column = 1 })
-                                { line = 12, column = 0 }
+                                (var "j" { line = 10, column = 0 })
+                                { line = 10, column = 0 }
                             )
-            ]
+                            (var "k" { line = 12, column = 1 })
+                            { line = 12, column = 0 }
+                        )
+        ]

--- a/tests/Statement.elm
+++ b/tests/Statement.elm
@@ -18,15 +18,14 @@ import Test exposing (describe, test, Test)
 import Helpers exposing (var, isStatement, areStatements)
 
 
-meta =
-    { line = 0, column = 0 }
-
-
 moduleDeclaration : Test
 moduleDeclaration =
     describe "Module declaration statements"
         [ test "simple declaration exposing all" <|
-            \() -> "module A exposing (..)" |> isStatement (ModuleDeclaration [ "A" ] AllExport meta)
+            \() ->
+                "module A exposing (..)"
+                    |> isStatement
+                        (ModuleDeclaration [ "A" ] AllExport { line = 1, column = 0 })
         , test "declaration exposing particular things" <|
             \() ->
                 "module A exposing (A, b)"
@@ -37,7 +36,7 @@ moduleDeclaration =
                                 , FunctionExport "b"
                                 ]
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "declaration exposing an infix operator" <|
             \() ->
@@ -45,7 +44,7 @@ moduleDeclaration =
                     |> isStatement
                         (ModuleDeclaration [ "A" ]
                             (SubsetExport [ FunctionExport "?" ])
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "declaration exposing union" <|
             \() ->
@@ -53,15 +52,21 @@ moduleDeclaration =
                     |> isStatement
                         (ModuleDeclaration [ "A" ]
                             (SubsetExport [ TypeExport "A" (Just AllExport) ])
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "declaration exposing constructor subset" <|
             \() ->
                 "module A exposing (A(A))"
                     |> isStatement
                         (ModuleDeclaration [ "A" ]
-                            (SubsetExport [ TypeExport "A" (Just <| SubsetExport [ FunctionExport "A" ]) ])
-                            meta
+                            (SubsetExport
+                                [ TypeExport "A"
+                                    (Just <|
+                                        SubsetExport [ FunctionExport "A" ]
+                                    )
+                                ]
+                            )
+                            { line = 1, column = 0 }
                         )
         , test "multiline declaration" <|
             \() ->
@@ -74,7 +79,7 @@ moduleDeclaration =
                                 , FunctionExport "c"
                                 ]
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "declaration using a port" <|
             \() ->
@@ -82,7 +87,7 @@ moduleDeclaration =
                     |> isStatement
                         (PortModuleDeclaration [ "A" ]
                             (SubsetExport [ TypeExport "A" (Just AllExport) ])
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "simple effects" <|
             \() ->
@@ -93,7 +98,7 @@ moduleDeclaration =
                             , ( "command", "MyCmd" )
                             ]
                             AllExport
-                            meta
+                            { line = 1, column = 0 }
                         )
         ]
 
@@ -102,13 +107,35 @@ importStatements : Test
 importStatements =
     describe "Import statements"
         [ test "simple import" <|
-            \() -> "import A" |> isStatement (ImportStatement [ "A" ] Nothing Nothing meta)
+            \() ->
+                "import A"
+                    |> isStatement
+                        (ImportStatement
+                            [ "A" ]
+                            Nothing
+                            Nothing
+                            { line = 1, column = 0 }
+                        )
         , test "import as" <|
-            \() -> "import A as B" |> isStatement (ImportStatement [ "A" ] (Just "B") Nothing meta)
+            \() ->
+                "import A as B"
+                    |> isStatement
+                        (ImportStatement
+                            [ "A" ]
+                            (Just "B")
+                            Nothing
+                            { line = 1, column = 0 }
+                        )
         , test "import exposing all" <|
             \() ->
                 "import A exposing (..)"
-                    |> isStatement (ImportStatement [ "A" ] Nothing (Just AllExport) meta)
+                    |> isStatement
+                        (ImportStatement
+                            [ "A" ]
+                            Nothing
+                            (Just AllExport)
+                            { line = 1, column = 0 }
+                        )
         , test "import exposing" <|
             \() ->
                 "import A exposing (A, b)"
@@ -122,7 +149,7 @@ importStatements =
                                     ]
                                 )
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "import exposing union" <|
             \() ->
@@ -131,9 +158,11 @@ importStatements =
                         (ImportStatement [ "A" ]
                             Nothing
                             (Just
-                                (SubsetExport [ TypeExport "A" (Just AllExport) ])
+                                (SubsetExport
+                                    [ TypeExport "A" (Just AllExport) ]
+                                )
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "import exposing constructor subset" <|
             \() ->
@@ -142,9 +171,11 @@ importStatements =
                         (ImportStatement [ "A" ]
                             Nothing
                             (Just
-                                (SubsetExport [ TypeExport "A" (Just <| SubsetExport [ FunctionExport "A" ]) ])
+                                (SubsetExport
+                                    [ TypeExport "A" (Just <| SubsetExport [ FunctionExport "A" ]) ]
+                                )
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "import multiline" <|
             \() ->
@@ -160,7 +191,7 @@ importStatements =
                                     ]
                                 )
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         ]
 
@@ -172,27 +203,44 @@ typeAnnotations =
             \() ->
                 "x : Int"
                     |> isStatement
-                        (FunctionTypeDeclaration "x" (TypeConstructor [ "Int" ] [] meta) meta)
+                        (FunctionTypeDeclaration
+                            "x"
+                            (TypeConstructor
+                                [ "Int" ]
+                                []
+                                { line = 1, column = 4 }
+                            )
+                            { line = 1, column = 0 }
+                        )
         , test "variables" <|
             \() ->
                 "x : a"
                     |> isStatement
-                        (FunctionTypeDeclaration "x" (TypeVariable "a" meta) meta)
+                        (FunctionTypeDeclaration
+                            "x"
+                            (TypeVariable "a" { line = 1, column = 4 })
+                            { line = 1, column = 0 }
+                        )
         , test "variables with numbers" <|
             \() ->
                 "x : a1"
                     |> isStatement
-                        (FunctionTypeDeclaration "x" (TypeVariable "a1" meta) meta)
+                        (FunctionTypeDeclaration
+                            "x"
+                            (TypeVariable "a1" { line = 1, column = 4 })
+                            { line = 1, column = 0 }
+                        )
         , test "application" <|
             \() ->
                 "x : a -> b"
                     |> isStatement
-                        (FunctionTypeDeclaration "x"
+                        (FunctionTypeDeclaration
+                            "x"
                             (TypeApplication
-                                (TypeVariable "a" meta)
-                                (TypeVariable "b" meta)
+                                (TypeVariable "a" { line = 1, column = 4 })
+                                (TypeVariable "b" { line = 1, column = 9 })
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "application associativity" <|
             \() ->
@@ -200,13 +248,13 @@ typeAnnotations =
                     |> isStatement
                         (FunctionTypeDeclaration "x"
                             (TypeApplication
-                                (TypeVariable "a" meta)
+                                (TypeVariable "a" { line = 1, column = 4 })
                                 (TypeApplication
-                                    (TypeVariable "b" meta)
-                                    (TypeVariable "c" meta)
+                                    (TypeVariable "b" { line = 1, column = 9 })
+                                    (TypeVariable "c" { line = 1, column = 14 })
                                 )
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "application parens" <|
             \() ->
@@ -215,12 +263,12 @@ typeAnnotations =
                         (FunctionTypeDeclaration "x"
                             (TypeApplication
                                 (TypeApplication
-                                    (TypeVariable "a" meta)
-                                    (TypeVariable "b" meta)
+                                    (TypeVariable "a" { line = 1, column = 5 })
+                                    (TypeVariable "b" { line = 1, column = 10 })
                                 )
-                                (TypeVariable "c" meta)
+                                (TypeVariable "c" { line = 1, column = 16 })
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "qualified types" <|
             \() ->
@@ -229,10 +277,10 @@ typeAnnotations =
                         (FunctionTypeDeclaration "m"
                             (TypeConstructor
                                 [ "Html", "App" ]
-                                [ (TypeConstructor [ "Msg" ] []) meta ]
-                                meta
+                                [ (TypeConstructor [ "Msg" ] [] { line = 1, column = 13 }) ]
+                                { line = 1, column = 4 }
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         ]
 
@@ -244,32 +292,45 @@ portStatements =
             \() ->
                 "port focus : String -> Cmd msg"
                     |> isStatement
-                        (PortTypeDeclaration "focus"
+                        (PortTypeDeclaration
+                            "focus"
                             (TypeApplication
-                                (TypeConstructor [ "String" ] [] meta)
+                                (TypeConstructor
+                                    [ "String" ]
+                                    []
+                                    { line = 1, column = 13 }
+                                )
                                 (TypeConstructor [ "Cmd" ]
-                                    [ TypeVariable "msg" meta ]
-                                    meta
+                                    ([ TypeVariable
+                                        "msg"
+                                        { line = 1, column = 27 }
+                                     ]
+                                    )
+                                    { line = 1, column = 23 }
                                 )
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "another port type declaration" <|
             \() ->
                 "port users : (User -> msg) -> Sub msg"
                     |> isStatement
-                        (PortTypeDeclaration "users"
+                        (PortTypeDeclaration
+                            "users"
                             (TypeApplication
                                 (TypeApplication
-                                    (TypeConstructor [ "User" ] [] meta)
-                                    (TypeVariable "msg" meta)
+                                    (TypeConstructor [ "User" ] [] { line = 1, column = 14 })
+                                    (TypeVariable
+                                        "msg"
+                                        { line = 1, column = 22 }
+                                    )
                                 )
                                 (TypeConstructor [ "Sub" ]
-                                    [ TypeVariable "msg" meta ]
-                                    meta
+                                    ([ TypeVariable "msg" { line = 1, column = 34 } ])
+                                    { line = 1, column = 30 }
                                 )
                             )
-                            meta
+                            { line = 1, column = 0 }
                         )
         , test "port definition" <|
             \() ->
@@ -277,12 +338,8 @@ portStatements =
                     |> isStatement
                         (PortDeclaration "focus"
                             []
-                            (Access
-                                (Variable [ "Cmd" ])
-                                [ "none" ]
-                                meta
-                            )
-                            meta
+                            (Access (Variable [ "Cmd" ]) [ "none" ] { line = 1, column = 13 })
+                            { line = 1, column = 0 }
                         )
         ]
 
@@ -293,15 +350,15 @@ infixDeclarations =
         [ test "non" <|
             \() ->
                 "infix 9 :-"
-                    |> isStatement (InfixDeclaration N 9 ":-" meta)
+                    |> isStatement (InfixDeclaration N 9 ":-" { line = 1, column = 0 })
         , test "left" <|
             \() ->
                 "infixl 9 :-"
-                    |> isStatement (InfixDeclaration L 9 ":-" meta)
+                    |> isStatement (InfixDeclaration L 9 ":-" { line = 1, column = 0 })
         , test "right" <|
             \() ->
                 "infixr 9 :-"
-                    |> isStatement (InfixDeclaration R 9 ":-" meta)
+                    |> isStatement (InfixDeclaration R 9 ":-" { line = 1, column = 0 })
         ]
 
 
@@ -322,18 +379,17 @@ singleDeclaration =
                 |> areStatements
                     [ FunctionTypeDeclaration "f"
                         (TypeApplication
-                            (TypeConstructor [ "Int" ] [] meta)
-                            (TypeConstructor [ "Int" ] [] meta)
+                            (TypeConstructor [ "Int" ] [] { line = 1, column = 3 })
+                            (TypeConstructor [ "Int" ] [] { line = 1, column = 10 })
                         )
-                        meta
+                        { line = 1, column = 0 }
                     , FunctionDeclaration "f"
-                        [ Variable [ "x" ] ]
-                        (BinOp
-                            (Variable [ "+" ])
+                        ([ Variable [ "x" ] ])
+                        (BinOp (Variable [ "+" ])
                             (Variable [ "x" ])
-                            (Integer 1 meta)
+                            (Integer 1 { line = 3, column = 5 })
                         )
-                        meta
+                        { line = 2, column = 0 }
                     ]
 
 
@@ -367,61 +423,67 @@ multipleDeclarations =
                 |> areStatements
                     [ FunctionTypeDeclaration "f"
                         (TypeApplication
-                            (TypeConstructor [ "Int" ] [] meta)
-                            (TypeConstructor [ "Int" ] [] meta)
+                            (TypeConstructor [ "Int" ] [] { line = 3, column = 3 })
+                            (TypeConstructor [ "Int" ] [] { line = 3, column = 10 })
                         )
-                        meta
+                        { line = 3, column = 0 }
                     , FunctionDeclaration "f"
-                        [ Variable [ "x" ] ]
+                        ([ Variable [ "x" ] ])
                         (BinOp
                             (Variable [ "+" ])
                             (Variable [ "x" ])
-                            (Integer 1 meta)
+                            (Integer 1 { line = 5, column = 5 })
                         )
-                        meta
+                        { line = 4, column = 0 }
                     , FunctionTypeDeclaration "g"
                         (TypeApplication
-                            (TypeConstructor [ "Int" ] [] meta)
-                            (TypeConstructor [ "Int" ] [] meta)
+                            (TypeConstructor [ "Int" ] [] { line = 7, column = 3 })
+                            (TypeConstructor [ "Int" ] [] { line = 7, column = 10 })
                         )
-                        meta
+                        { line = 7, column = 0 }
                     , FunctionDeclaration "g"
-                        [ Variable [ "x" ] ]
-                        (BinOp
-                            (Variable [ "+" ])
-                            (Application
-                                (Variable [ "f" ])
-                                (Variable [ "x" ])
-                            )
-                            (Integer 1 meta)
+                        ([ Variable [ "x" ] ])
+                        (BinOp (Variable [ "+" ])
+                            (Application (Variable [ "f" ]) (Variable [ "x" ]))
+                            (Integer 1 { line = 9, column = 7 })
                         )
-                        meta
+                        { line = 8, column = 0 }
                     , FunctionTypeDeclaration "h"
                         (TypeApplication
                             (TypeTuple
-                                [ TypeConstructor [ "Int" ] [] meta
-                                , TypeConstructor [ "Int" ] [] meta
-                                ]
-                                meta
+                                ([ TypeConstructor [ "Int" ]
+                                    []
+                                    { line = 11, column = 4 }
+                                 , TypeConstructor [ "Int" ] [] { line = 11, column = 9 }
+                                 ]
+                                )
+                                { line = 11, column = 3 }
                             )
-                            (TypeConstructor [ "Int" ] [] meta)
+                            (TypeConstructor [ "Int" ] [] { line = 11, column = 17 })
                         )
-                        meta
+                        { line = 11, column = 0 }
                     , FunctionDeclaration "h"
-                        [ Tuple [ (Variable [ "a" ]), (Variable [ "b" ]) ] meta ]
+                        ([ Tuple
+                            ([ Variable [ "a" ], Variable [ "b" ] ])
+                            { line = 12, column = 1 }
+                         ]
+                        )
                         (BinOp
                             (Variable [ "+" ])
                             (Variable [ "a" ])
                             (Variable [ "b" ])
                         )
-                        meta
+                        { line = 12, column = 0 }
                     , FunctionTypeDeclaration "+"
                         (TypeApplication
-                            (TypeConstructor [ "Int" ] [] meta)
-                            (TypeConstructor [ "Int" ] [] meta)
+                            (TypeConstructor [ "Int" ] [] { line = 14, column = 5 })
+                            (TypeConstructor [ "Int" ] [] { line = 14, column = 12 })
                         )
-                        meta
-                    , FunctionDeclaration "+" [ Variable [ "a" ], Variable [ "b" ] ] (Integer 1 meta) meta
+                        { line = 14, column = 0 }
+                    , FunctionDeclaration "+"
+                        ([ Variable [ "a" ], Variable [ "b" ] ])
+                        (Integer 1 { line = 16, column = 1 })
+                        { line = 15, column = 0 }
                     ]
 
 
@@ -446,8 +508,7 @@ moduleFixityDeclarations =
                 |> areStatements
                     [ FunctionDeclaration "f"
                         []
-                        (BinOp
-                            (Variable [ "++" ])
+                        (BinOp (Variable [ "++" ])
                             (BinOp
                                 (Variable [ "++" ])
                                 (Variable [ "a" ])
@@ -455,21 +516,17 @@ moduleFixityDeclarations =
                             )
                             (Variable [ "c" ])
                         )
-                        meta
-                    , InfixDeclaration L 1 "++" meta
+                        { line = 1, column = 0 }
+                    , InfixDeclaration L 1 "++" { line = 3, column = 0 }
                     , FunctionDeclaration "g"
                         []
                         (BinOp
                             (Variable [ "**" ])
                             (Variable [ "a" ])
-                            (BinOp
-                                (Variable [ "**" ])
-                                (Variable [ "b" ])
-                                (Variable [ "c" ])
-                            )
+                            (BinOp (Variable [ "**" ]) (Variable [ "b" ]) (Variable [ "c" ]))
                         )
-                        meta
-                    , InfixDeclaration R 1 "**" meta
+                        { line = 5, column = 0 }
+                    , InfixDeclaration R 1 "**" { line = 7, column = 0 }
                     ]
 
 
@@ -495,17 +552,17 @@ typeDeclarations =
                 emptyRecordAliasInput
                     |> areStatements
                         [ TypeAliasDeclaration
-                            (TypeConstructor [ "A" ] [] meta)
-                            (TypeRecord [] meta)
-                            meta
+                            (TypeConstructor [ "A" ] [] { line = 1, column = 10 })
+                            (TypeRecord [] { line = 1, column = 15 })
+                            { line = 1, column = 0 }
                         ]
         , test "can parse aliases of unit" <|
             \() ->
                 emptyTupleAliasInput
                     |> areStatements
                         [ TypeAliasDeclaration
-                            (TypeConstructor [ "A" ] [] meta)
-                            (TypeTuple [] meta)
-                            meta
+                            (TypeConstructor [ "A" ] [] { line = 1, column = 10 })
+                            (TypeTuple [] { line = 1, column = 14 })
+                            { line = 1, column = 0 }
                         ]
         ]

--- a/tests/Statement.elm
+++ b/tests/Statement.elm
@@ -338,7 +338,11 @@ portStatements =
                     |> isStatement
                         (PortDeclaration "focus"
                             []
-                            (Access (Variable [ "Cmd" ]) [ "none" ] { line = 1, column = 13 })
+                            (Access
+                                (var "Cmd" { line = 1, column = 13 })
+                                [ "none" ]
+                                { line = 1, column = 13 }
+                            )
                             { line = 1, column = 0 }
                         )
         ]
@@ -384,10 +388,12 @@ singleDeclaration =
                         )
                         { line = 1, column = 0 }
                     , FunctionDeclaration "f"
-                        ([ Variable [ "x" ] ])
-                        (BinOp (Variable [ "+" ])
-                            (Variable [ "x" ])
+                        ([ var "x" { line = 2, column = 1 } ])
+                        (BinOp
+                            (var "+" { line = 3, column = 4 })
+                            (var "x" { line = 3, column = 1 })
                             (Integer 1 { line = 3, column = 5 })
+                            { line = 3, column = 4 }
                         )
                         { line = 2, column = 0 }
                     ]
@@ -428,11 +434,12 @@ multipleDeclarations =
                         )
                         { line = 3, column = 0 }
                     , FunctionDeclaration "f"
-                        ([ Variable [ "x" ] ])
+                        ([ var "x" { line = 4, column = 1 } ])
                         (BinOp
-                            (Variable [ "+" ])
-                            (Variable [ "x" ])
+                            (var "+" { line = 5, column = 4 })
+                            (var "x" { line = 5, column = 1 })
                             (Integer 1 { line = 5, column = 5 })
+                            { line = 5, column = 4 }
                         )
                         { line = 4, column = 0 }
                     , FunctionTypeDeclaration "g"
@@ -442,10 +449,16 @@ multipleDeclarations =
                         )
                         { line = 7, column = 0 }
                     , FunctionDeclaration "g"
-                        ([ Variable [ "x" ] ])
-                        (BinOp (Variable [ "+" ])
-                            (Application (Variable [ "f" ]) (Variable [ "x" ]))
+                        ([ var "x" { line = 8, column = 1 } ])
+                        (BinOp
+                            (var "+" { line = 9, column = 6 })
+                            (Application
+                                (var "f" { line = 9, column = 1 })
+                                (var "x" { line = 9, column = 3 })
+                                { line = 9, column = 2 }
+                            )
                             (Integer 1 { line = 9, column = 7 })
+                            { line = 9, column = 6 }
                         )
                         { line = 8, column = 0 }
                     , FunctionTypeDeclaration "h"
@@ -454,34 +467,56 @@ multipleDeclarations =
                                 ([ TypeConstructor [ "Int" ]
                                     []
                                     { line = 11, column = 4 }
-                                 , TypeConstructor [ "Int" ] [] { line = 11, column = 9 }
+                                 , TypeConstructor
+                                    [ "Int" ]
+                                    []
+                                    { line = 11, column = 9 }
                                  ]
                                 )
                                 { line = 11, column = 3 }
                             )
-                            (TypeConstructor [ "Int" ] [] { line = 11, column = 17 })
+                            (TypeConstructor
+                                [ "Int" ]
+                                []
+                                { line = 11, column = 17 }
+                            )
                         )
                         { line = 11, column = 0 }
                     , FunctionDeclaration "h"
                         ([ Tuple
-                            ([ Variable [ "a" ], Variable [ "b" ] ])
+                            ([ var "a" { line = 12, column = 2 }
+                             , var "b" { line = 12, column = 5 }
+                             ]
+                            )
                             { line = 12, column = 1 }
                          ]
                         )
                         (BinOp
-                            (Variable [ "+" ])
-                            (Variable [ "a" ])
-                            (Variable [ "b" ])
+                            (var "+" { line = 12, column = 13 })
+                            (var "a" { line = 12, column = 10 })
+                            (var "b" { line = 12, column = 14 })
+                            { line = 12, column = 13 }
                         )
                         { line = 12, column = 0 }
                     , FunctionTypeDeclaration "+"
                         (TypeApplication
-                            (TypeConstructor [ "Int" ] [] { line = 14, column = 5 })
-                            (TypeConstructor [ "Int" ] [] { line = 14, column = 12 })
+                            (TypeConstructor
+                                [ "Int" ]
+                                []
+                                { line = 14, column = 5 }
+                            )
+                            (TypeConstructor
+                                [ "Int" ]
+                                []
+                                { line = 14, column = 12 }
+                            )
                         )
                         { line = 14, column = 0 }
                     , FunctionDeclaration "+"
-                        ([ Variable [ "a" ], Variable [ "b" ] ])
+                        ([ var "a" { line = 15, column = 3 }
+                         , var "b" { line = 15, column = 5 }
+                         ]
+                        )
                         (Integer 1 { line = 16, column = 1 })
                         { line = 15, column = 0 }
                     ]
@@ -508,22 +543,31 @@ moduleFixityDeclarations =
                 |> areStatements
                     [ FunctionDeclaration "f"
                         []
-                        (BinOp (Variable [ "++" ])
+                        (BinOp
+                            (var "++" { line = 1, column = 12 })
                             (BinOp
-                                (Variable [ "++" ])
-                                (Variable [ "a" ])
-                                (Variable [ "b" ])
+                                (var "++" { line = 1, column = 7 })
+                                (var "a" { line = 1, column = 3 })
+                                (var "b" { line = 1, column = 8 })
+                                { line = 1, column = 7 }
                             )
-                            (Variable [ "c" ])
+                            (var "c" { line = 1, column = 13 })
+                            { line = 1, column = 12 }
                         )
                         { line = 1, column = 0 }
                     , InfixDeclaration L 1 "++" { line = 3, column = 0 }
                     , FunctionDeclaration "g"
                         []
                         (BinOp
-                            (Variable [ "**" ])
-                            (Variable [ "a" ])
-                            (BinOp (Variable [ "**" ]) (Variable [ "b" ]) (Variable [ "c" ]))
+                            (var "**" { line = 5, column = 7 })
+                            (var "a" { line = 5, column = 3 })
+                            (BinOp
+                                (var "**" { line = 5, column = 12 })
+                                (var "b" { line = 5, column = 8 })
+                                (var "c" { line = 5, column = 13 })
+                                { line = 5, column = 12 }
+                            )
+                            { line = 5, column = 7 }
                         )
                         { line = 5, column = 0 }
                     , InfixDeclaration R 1 "**" { line = 7, column = 0 }

--- a/tests/Statement.elm
+++ b/tests/Statement.elm
@@ -239,6 +239,7 @@ typeAnnotations =
                             (TypeApplication
                                 (TypeVariable "a" { line = 1, column = 4 })
                                 (TypeVariable "b" { line = 1, column = 9 })
+                                { line = 1, column = 6 }
                             )
                             { line = 1, column = 0 }
                         )
@@ -252,7 +253,9 @@ typeAnnotations =
                                 (TypeApplication
                                     (TypeVariable "b" { line = 1, column = 9 })
                                     (TypeVariable "c" { line = 1, column = 14 })
+                                    { line = 1, column = 11 }
                                 )
+                                { line = 1, column = 6 }
                             )
                             { line = 1, column = 0 }
                         )
@@ -265,8 +268,10 @@ typeAnnotations =
                                 (TypeApplication
                                     (TypeVariable "a" { line = 1, column = 5 })
                                     (TypeVariable "b" { line = 1, column = 10 })
+                                    { line = 1, column = 7 }
                                 )
                                 (TypeVariable "c" { line = 1, column = 16 })
+                                { line = 1, column = 13 }
                             )
                             { line = 1, column = 0 }
                         )
@@ -308,6 +313,7 @@ portStatements =
                                     )
                                     { line = 1, column = 23 }
                                 )
+                                { line = 1, column = 20 }
                             )
                             { line = 1, column = 0 }
                         )
@@ -324,11 +330,13 @@ portStatements =
                                         "msg"
                                         { line = 1, column = 22 }
                                     )
+                                    { line = 1, column = 19 }
                                 )
                                 (TypeConstructor [ "Sub" ]
                                     ([ TypeVariable "msg" { line = 1, column = 34 } ])
                                     { line = 1, column = 30 }
                                 )
+                                { line = 1, column = 27 }
                             )
                             { line = 1, column = 0 }
                         )
@@ -385,6 +393,7 @@ singleDeclaration =
                         (TypeApplication
                             (TypeConstructor [ "Int" ] [] { line = 1, column = 3 })
                             (TypeConstructor [ "Int" ] [] { line = 1, column = 10 })
+                            { line = 1, column = 7 }
                         )
                         { line = 1, column = 0 }
                     , FunctionDeclaration "f"
@@ -431,6 +440,7 @@ multipleDeclarations =
                         (TypeApplication
                             (TypeConstructor [ "Int" ] [] { line = 3, column = 3 })
                             (TypeConstructor [ "Int" ] [] { line = 3, column = 10 })
+                            { line = 3, column = 7 }
                         )
                         { line = 3, column = 0 }
                     , FunctionDeclaration "f"
@@ -446,6 +456,7 @@ multipleDeclarations =
                         (TypeApplication
                             (TypeConstructor [ "Int" ] [] { line = 7, column = 3 })
                             (TypeConstructor [ "Int" ] [] { line = 7, column = 10 })
+                            { line = 7, column = 7 }
                         )
                         { line = 7, column = 0 }
                     , FunctionDeclaration "g"
@@ -480,6 +491,7 @@ multipleDeclarations =
                                 []
                                 { line = 11, column = 17 }
                             )
+                            { line = 11, column = 14 }
                         )
                         { line = 11, column = 0 }
                     , FunctionDeclaration "h"
@@ -510,6 +522,7 @@ multipleDeclarations =
                                 []
                                 { line = 14, column = 12 }
                             )
+                            { line = 14, column = 9 }
                         )
                         { line = 14, column = 0 }
                     , FunctionDeclaration "+"


### PR DESCRIPTION
### Huge thanks to @joeandaverde for creating most of what is implemented in this PR in the first place. Also shoutout to the @laslowh who helped with rest of the types. You're the best!!! 🎉

All Expressions and Statements now have Meta as last argument `{ line: Int, column: Int }`.
Positional information are not perfect. There as some cases where whitespaces are omitted in column count but besides everything works as expected. 

This is big breaking change and I'm counting on your feedback.

Fixes: #13 
***
~~Almost all types are converted contain meta information except:~~
- [x] ~~TypeApplication~~
- [x] ~~Application~~
- [x] ~~BinOp~~
- [x] ~~Variable~~

~~They are advanced because of~~
- ~~partial application in case of `TypeApplication` and `Application`~~
- ~~creating in place `Variable` and `BinOp` types~~

~I was trying implement Meta for those as well but I've failed lacking knowledge and full understanding of `parser-combinators` as well as advanced Elm. That why I'm creating this WIP PR,  counting on your support.~~
